### PR TITLE
docs: warning for linux users

### DIFF
--- a/botfront/docs/guide/getting-started/quick-start.md
+++ b/botfront/docs/guide/getting-started/quick-start.md
@@ -9,6 +9,10 @@ This tutorial will guide you through the installation and the development of you
 
 If you already have Docker installed, make sure it's up to date.
 
+::: warning Linux users
+`host.docker.internal` does not resolve on Docker for linux, see [this issue](https://github.com/docker/for-linux/issues/264) for possible solutions.
+:::
+
 ## Install Botfront
 
 Open your terminal 


### PR DESCRIPTION
## warning for linux users

Docker for linux does not support host.docker.internal, we added a warning that explains the issue and link to the actual docker issue on Github


I made sure to
- [x] document the feature if needed
