### PR TITLE
Feat/chat support no language

### DIFF
--- a/botfront/cypress/integration/chat/chat.spec.js
+++ b/botfront/cypress/integration/chat/chat.spec.js
@@ -21,6 +21,32 @@ describe('chat side panel handling', function() {
         cy.get('[data-cy=chat-pane]').should('not.exist');
     });
 
+    it('should display a message when no language are set', function() {
+        cy.visit(`/project/${this.bf_project_id}/nlu/models`);
+        cy.get('[data-cy=duplicate-button]').click();
+        cy.get('[data-cy=confirm-popup]').contains('Yes').click();
+        cy.get('[data-cy=offline-model]').click();
+        cy.get('[data-cy=confirm-popup]').contains('Yes').click();
+        cy.get('[data-cy=open-model]')
+            .eq(1)
+            .click();
+        cy.get('.nlu-menu-settings').click();
+        cy.contains('Delete').click();
+        cy.get('.nlu-menu-settings').click();
+        cy.get('.dowload-model-backup-button').click();
+        cy.get('.delete-model-button').click();
+        cy.get('.ui.page.modals .primary').click();
+
+        cy.visit(`/project/${this.bf_project_id}/nlu/models`);
+        cy.get('[data-cy=open-chat]').click();
+        cy.get('[data-cy=no-language]');
+        cy.get('[data-cy=chat-language-option]').should('not.exist');
+        cy.get('[data-cy=close-chat]').click();
+
+        cy.get('[data-cy=offline-model]').click();
+        cy.get('[data-cy=confirm-popup]').contains('Yes').click();
+    });
+
     it('should remove the core instance and the chat should display a message', function() {
         cy.visit(`/project/${this.bf_project_id}/settings`);
 

--- a/botfront/imports/ui/components/project/Chat.jsx
+++ b/botfront/imports/ui/components/project/Chat.jsx
@@ -32,7 +32,11 @@ class Chat extends React.Component {
 Chat.propTypes = {
     socketUrl: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
-    language: PropTypes.string.isRequired,
+    language: PropTypes.string,
+};
+
+Chat.defaultProps = {
+    language: '',
 };
 
 export default Chat;

--- a/botfront/imports/ui/components/project/ProjectChat.jsx
+++ b/botfront/imports/ui/components/project/ProjectChat.jsx
@@ -61,7 +61,7 @@ class ProjectChat extends React.Component {
                         text: model.language,
                         value: model.language,
                     })),
-                    selectedLanguage: res[0].language,
+                    selectedLanguage: res.length ? res[0].language : '',
                 });
             }),
         );
@@ -97,13 +97,15 @@ class ProjectChat extends React.Component {
             <div className='chat-pane-container' data-cy='chat-pane'>
                 <Menu pointing secondary>
                     <Menu.Item>
-                        <Dropdown
-                            options={languageOptions}
-                            selection
-                            onChange={this.handleLangChange}
-                            value={selectedLanguage}
-                            data-cy='chat-language-option'
-                        />
+                        {selectedLanguage && (
+                            <Dropdown
+                                options={languageOptions}
+                                selection
+                                onChange={this.handleLangChange}
+                                value={selectedLanguage}
+                                data-cy='chat-language-option'
+                            />
+                        )}
                     </Menu.Item>
                     <Menu.Menu position='right'>
                         <Menu.Item>
@@ -142,37 +144,45 @@ class ProjectChat extends React.Component {
                         </Menu.Item>
                     </Menu.Menu>
                 </Menu>
-                <div>
-                    {socketUrl && selectedLanguage && path && (
-                        <Chat
-                            socketUrl={socketUrl}
-                            key={key}
-                            language={selectedLanguage}
-                            path={path}
-                        />
-                    )}
-                    {noCore && (
-                        <Message
-                            content={(
-                                <div>
-                                    Go to <Icon name='setting' />Settings &gt;{' '}
-                                    <Icon name='server' />Instances to{' '}
-                                    <Link
-                                        to={`/project/${projectId}/settings`}
-                                        onClick={triggerChatPane}
-                                        data-cy='settings-link'
-                                    >
-                                        create{' '}
-                                    </Link>
-                                    an instance of type <b>core</b> to enable the chat window.
-                                </div>
-                            )}
-                            className='no-core-message'
-                            warning
-                            data-cy='no-core-instance-message'
-                        />
-                    )}
-                </div>
+                {selectedLanguage === '' && (
+                    <Message warning className='no-language' data-cy='no-language'>
+                        There is no <Icon name='wifi' /><b>online</b> NLU model, so your chatbot cannot understand natural
+                        language. However you can use dialog acts like <code>/intent</code> or{' '}
+                        <code>
+                            /intent{'{'}&quot;entity&quot;:&quot;value&quot;{'}'}
+                        </code>
+                    </Message>
+                )}
+                {socketUrl && (selectedLanguage || selectedLanguage === '') && path && (
+                    <Chat
+                        socketUrl={socketUrl}
+                        key={key}
+                        language={selectedLanguage}
+                        path={path}
+                    />
+                )}
+                {noCore && (
+                    <Message
+                        content={(
+                            <div>
+                                Go to <Icon name='setting' />
+                                Settings &gt; <Icon name='server' />
+                                Instances to{' '}
+                                <Link
+                                    to={`/project/${projectId}/settings`}
+                                    onClick={triggerChatPane}
+                                    data-cy='settings-link'
+                                >
+                                    create{' '}
+                                </Link>
+                                an instance of type <b>core</b> to enable the chat window.
+                            </div>
+                        )}
+                        className='no-core-message'
+                        warning
+                        data-cy='no-core-instance-message'
+                    />
+                )}
             </div>
         );
     }

--- a/botfront/imports/ui/layouts/project.import.less
+++ b/botfront/imports/ui/layouts/project.import.less
@@ -104,11 +104,6 @@
     right: 16px;
 }
 
-.chat-pane-container {
-    background-color: white;
-    
-}
-
 .project-children .ui.container {
     max-width: 1200px !important;
     width: ~"calc(100% - 80px)";
@@ -172,43 +167,60 @@
     transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
 }
   
-.chat-pane-container .menu.pointing {
-    padding: 0;
-    margin: 0;
-    height: @top-menu-height;
-}
+.chat-pane-container {
+    background-color: white;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
 
-.chat-pane-container .conversation-container {
-    box-shadow: none;
-    height: calc(~"100% - " @top-menu-height) !important;
-}
+    .menu.pointing {
+        padding: 0;
+        margin: 0;
+        min-height: @top-menu-height;
+        height: @top-menu-height;
 
-.chat-pane-container .ui.selection.dropdown {
-    position: relative;
-    min-width: 120px;
-    min-height: 2.4em;
-    top: 6px;
-    padding: 0.65em 1em;
-}
+        .ui.selection.dropdown {
+            position: relative;
+            min-width: 120px;
+            min-height: 2.4em;
+            top: 6px;
+            padding: 0.65em 1em;
 
-.chat-pane-container .ui.selection.dropdown .menu .active.item {
-    border-color: transparent;
-}
+            .menu .active.item {
+                border-color: transparent;
+            }
 
-.chat-pane-container .ui.menu .right.menu {
-    margin-bottom: 3px;
-}
+            .menu .active.item:hover {
+                border-color: transparent;
+            }
+        }
 
-.chat-pane-container .ui.selection.dropdown .menu .active.item:hover {
-    border-color: transparent;
+        .right.menu {
+            margin-bottom: 3px;
+        }
+    }
+
+    .ui.message.no-language {
+        margin: 1em;
+        min-height: auto;
+    }
+
+    .ui.message.no-core-message {
+        margin: 1em;
+    }
+
+    .conversation-container {
+        box-shadow: none;
+        height: 100%;
+    }
+
+    .widget-embedded {
+        position: unset;
+    }
 }
 
 .ui.bottom.right.popup.redo-chat-popup {
     margin-right: -12px;
-}
-
-.chat-pane-container .ui.message.no-core-message {
-    margin: 1em;
 }
 
 .Pane.vertical.Pane1 > div {


### PR DESCRIPTION
## Added no language support for the side chat

Made it so that the side chat still works if there are no published models.
This way you can still send messages like /intent to try out your responses.
Also added a message to explain the situation.


I made sure to
- [x] write tests for the feature
- [x] run all tests
- [x] document the feature if needed