### PR TITLE
fix issue 28, allowed characters for project name in settings page

### DIFF
--- a/botfront/imports/api/project/project.schema.default.js
+++ b/botfront/imports/api/project/project.schema.default.js
@@ -2,7 +2,13 @@ import SimpleSchema from 'simpl-schema';
 import { TemplateSchema } from './response.schema';
 
 export const ProjectsSchema = new SimpleSchema({
-    name: { type: String, index: 1 },
+    name: {
+        type: String,
+        index: 1,
+        custom() {
+            return !this.value.match(/^[A-Za-z0-9 ]+$/) ? 'name' : null;
+        },
+    },
     // apiKey: { type: String, optional: true },
     // namespace: {
     //     type: String, regEx: /^[a-z0-9-_]+$/, unique: 1, sparse: 1,
@@ -23,6 +29,12 @@ export const ProjectsSchema = new SimpleSchema({
     },
 
 }, { tracker: Tracker });
+
+ProjectsSchema.messageBox.messages({
+    en: {
+        name: 'The name can only contain alphanumeric characters',
+    },
+});
 
 ProjectsSchema.messageBox.messages({
     en: {


### PR DESCRIPTION
## Fix issue 28

adds a custom function in the default project schema to check if characters used in the name of the projects are alphanumeric.
also adds an error message if characters are not alphanumeric.
related: #28 