### PR TITLE
chore(entity-popup): Removed entity popup from playground

### DIFF
--- a/botfront/imports/ui/components/example_editor/EntityPopup.jsx
+++ b/botfront/imports/ui/components/example_editor/EntityPopup.jsx
@@ -132,7 +132,12 @@ class EntityPopup extends React.Component {
     };
 
     render() {
-        const { trigger, selection, length } = this.props;
+        const {
+            trigger,
+            selection,
+            length,
+            disableEntityPopup,
+        } = this.props;
         const { open } = this.state;
         return (
             <span
@@ -154,6 +159,7 @@ class EntityPopup extends React.Component {
                     )}
                     position='top center'
                     open={selection || open}
+                    disabled={disableEntityPopup}
                 />
             </span>
         );
@@ -170,6 +176,7 @@ EntityPopup.propTypes = {
     selection: PropTypes.bool,
     onSelectionReset: PropTypes.func,
     length: PropTypes.number.isRequired,
+    disableEntityPopup: PropTypes.bool,
 };
 
 EntityPopup.defaultProps = {
@@ -177,6 +184,7 @@ EntityPopup.defaultProps = {
     onDelete: () => {},
     selection: false,
     onSelectionReset: () => {},
+    disableEntityPopup: false,
 };
 
 export default EntityPopup;

--- a/botfront/imports/ui/components/example_editor/EntityPopup.jsx
+++ b/botfront/imports/ui/components/example_editor/EntityPopup.jsx
@@ -136,7 +136,7 @@ class EntityPopup extends React.Component {
             trigger,
             selection,
             length,
-            disableEntityPopup,
+            disabled,
         } = this.props;
         const { open } = this.state;
         return (
@@ -159,7 +159,7 @@ class EntityPopup extends React.Component {
                     )}
                     position='top center'
                     open={selection || open}
-                    disabled={disableEntityPopup}
+                    disabled={disabled}
                 />
             </span>
         );
@@ -176,7 +176,7 @@ EntityPopup.propTypes = {
     selection: PropTypes.bool,
     onSelectionReset: PropTypes.func,
     length: PropTypes.number.isRequired,
-    disableEntityPopup: PropTypes.bool,
+    disabled: PropTypes.bool,
 };
 
 EntityPopup.defaultProps = {
@@ -184,7 +184,7 @@ EntityPopup.defaultProps = {
     onDelete: () => {},
     selection: false,
     onSelectionReset: () => {},
-    disableEntityPopup: false,
+    disabled: false,
 };
 
 export default EntityPopup;

--- a/botfront/imports/ui/components/example_editor/NLUExampleTester.jsx
+++ b/botfront/imports/ui/components/example_editor/NLUExampleTester.jsx
@@ -86,13 +86,20 @@ export default class NLUExampleTester extends React.Component {
 
     render() {
         const { clickable, example } = this.state;
-        const { entities } = this.props;
+        const { entities, disableEntityPopup } = this.props;
         const optionalProps = clickable ? { onClick: this.onDone } : {};
         return (
             <div className='tester' {...optionalProps} data-cy='nlu-example-tester'>
                 {example && (
                     <Segment>
-                        <NLUExampleText onEnter={this.onDone} example={example} entities={entities} showIntent showLabels />
+                        <NLUExampleText
+                            onEnter={this.onDone}
+                            example={example}
+                            entities={entities}
+                            showIntent
+                            showLabels
+                            disableEntityPopup={disableEntityPopup}
+                        />
                     </Segment>
                 )}
             </div>

--- a/botfront/imports/ui/components/example_editor/NLUExampleTester.jsx
+++ b/botfront/imports/ui/components/example_editor/NLUExampleTester.jsx
@@ -86,7 +86,7 @@ export default class NLUExampleTester extends React.Component {
 
     render() {
         const { clickable, example } = this.state;
-        const { entities, disableEntityPopup } = this.props;
+        const { entities, disablePopup } = this.props;
         const optionalProps = clickable ? { onClick: this.onDone } : {};
         return (
             <div className='tester' {...optionalProps} data-cy='nlu-example-tester'>
@@ -98,7 +98,7 @@ export default class NLUExampleTester extends React.Component {
                             entities={entities}
                             showIntent
                             showLabels
-                            disableEntityPopup={disableEntityPopup}
+                            disablePopup={disablePopup}
                         />
                     </Segment>
                 )}
@@ -114,4 +114,10 @@ NLUExampleTester.propTypes = {
     instance: PropTypes.object.isRequired,
     entities: PropTypes.array.isRequired,
     onDone: PropTypes.func,
+    disablePopup: PropTypes.bool,
+};
+
+NLUExampleTester.defaultProps = {
+    onDone: () => {},
+    disablePopup: false,
 };

--- a/botfront/imports/ui/components/example_editor/NLUExampleText.jsx
+++ b/botfront/imports/ui/components/example_editor/NLUExampleText.jsx
@@ -33,7 +33,7 @@ class NLUExampleText extends React.Component {
             example,
             entities,
             showLabels,
-            disableEntityPopup,
+            disablePopup,
         } = this.props;
         const { stateEntity, selectedEntity } = this.state;
 
@@ -124,7 +124,7 @@ class NLUExampleText extends React.Component {
                             )}
                             key={`${e.start}${e.end}`}
                             selection
-                            disableEntityPopup={disableEntityPopup}
+                            disable={disablePopup}
                         />,
                     );
                 } else {
@@ -146,7 +146,7 @@ class NLUExampleText extends React.Component {
                                 />
                             )}
                             key={`${e.start}${e.end}`}
-                            disableEntityPopup={disableEntityPopup}
+                            disable={disablePopup}
                         />,
                     );
                 }
@@ -398,7 +398,7 @@ NLUExampleText.propTypes = {
     withMargin: PropTypes.bool,
     onSave: PropTypes.func.isRequired,
     editable: PropTypes.bool,
-    disableEntityPopup: PropTypes.bool,
+    disablePopup: PropTypes.bool,
 };
 
 NLUExampleText.defaultProps = {
@@ -408,7 +408,7 @@ NLUExampleText.defaultProps = {
     showLabels: false,
     withMargin: false,
     editable: false,
-    disableEntityPopup: false,
+    disablePopup: false,
 };
 
 export default NLUExampleText;

--- a/botfront/imports/ui/components/example_editor/NLUExampleText.jsx
+++ b/botfront/imports/ui/components/example_editor/NLUExampleText.jsx
@@ -396,7 +396,7 @@ NLUExampleText.propTypes = {
     showIntent: PropTypes.bool,
     showLabels: PropTypes.bool,
     withMargin: PropTypes.bool,
-    onSave: PropTypes.func.isRequired,
+    onSave: PropTypes.func,
     editable: PropTypes.bool,
     disablePopup: PropTypes.bool,
 };
@@ -409,6 +409,7 @@ NLUExampleText.defaultProps = {
     withMargin: false,
     editable: false,
     disablePopup: false,
+    onSave: () => {},
 };
 
 export default NLUExampleText;

--- a/botfront/imports/ui/components/example_editor/NLUExampleText.jsx
+++ b/botfront/imports/ui/components/example_editor/NLUExampleText.jsx
@@ -29,7 +29,12 @@ class NLUExampleText extends React.Component {
     };
 
     renderText = () => {
-        const { example, entities, showLabels } = this.props;
+        const {
+            example,
+            entities,
+            showLabels,
+            disableEntityPopup,
+        } = this.props;
         const { stateEntity, selectedEntity } = this.state;
 
         let concatenatedEntities = example.entities;
@@ -119,6 +124,7 @@ class NLUExampleText extends React.Component {
                             )}
                             key={`${e.start}${e.end}`}
                             selection
+                            disableEntityPopup={disableEntityPopup}
                         />,
                     );
                 } else {
@@ -140,6 +146,7 @@ class NLUExampleText extends React.Component {
                                 />
                             )}
                             key={`${e.start}${e.end}`}
+                            disableEntityPopup={disableEntityPopup}
                         />,
                     );
                 }
@@ -391,6 +398,7 @@ NLUExampleText.propTypes = {
     withMargin: PropTypes.bool,
     onSave: PropTypes.func.isRequired,
     editable: PropTypes.bool,
+    disableEntityPopup: PropTypes.bool,
 };
 
 NLUExampleText.defaultProps = {
@@ -400,6 +408,7 @@ NLUExampleText.defaultProps = {
     showLabels: false,
     withMargin: false,
     editable: false,
+    disableEntityPopup: false,
 };
 
 export default NLUExampleText;

--- a/botfront/imports/ui/components/example_editor/NLUPlayground.jsx
+++ b/botfront/imports/ui/components/example_editor/NLUPlayground.jsx
@@ -68,7 +68,7 @@ export default class NLUPlayground extends React.Component {
                                 projectId={projectId}
                                 entities={entities}
                                 onDone={this.handleExampleTested}
-                                disableEntityPopup
+                                disablePopup
                             />
                         )}
                     </div>

--- a/botfront/imports/ui/components/example_editor/NLUPlayground.jsx
+++ b/botfront/imports/ui/components/example_editor/NLUPlayground.jsx
@@ -68,6 +68,7 @@ export default class NLUPlayground extends React.Component {
                                 projectId={projectId}
                                 entities={entities}
                                 onDone={this.handleExampleTested}
+                                disableEntityPopup
                             />
                         )}
                     </div>


### PR DESCRIPTION
Entity popup is not available in the playground. This feature is not tested as it not possible to select text in cypress. Also altered some code for removing lint error
