### PR TITLE
fix(add-language): backspace cannot be used to remove a language

### DIFF
--- a/botfront/imports/ui/components/settings/ProjectInfo.jsx
+++ b/botfront/imports/ui/components/settings/ProjectInfo.jsx
@@ -20,7 +20,11 @@ class ProjectInfo extends React.Component {
         super(props);
         const { modelLanguages } = this.props;
         const languageValues = modelLanguages.map(lang => lang.value);
-        this.state = { saving: false, value: languageValues, supportedLanguages: languageValues };
+        this.state = {
+            saving: false,
+            value: languageValues,
+            supportedLanguages: languageValues,
+        };
     }
 
     getOptions = () => {
@@ -57,8 +61,8 @@ class ProjectInfo extends React.Component {
         if (renderNewValue) {
             this.setState({ saving: false, value: newValue });
         }
-    }
-        
+    };
+
     createNLUModels = (languageArray, projectId, newSupportedLanguages) => {
         const nluInsertArray = languageArray.map(language => Meteor.callWithPromise(
             'nlu.insert',
@@ -70,7 +74,10 @@ class ProjectInfo extends React.Component {
             projectId,
         ));
         Promise.all(nluInsertArray).then(() => {
-            this.setState({ saving: false, supportedLanguages: newSupportedLanguages });
+            this.setState({
+                saving: false,
+                supportedLanguages: newSupportedLanguages,
+            });
         });
     };
 
@@ -81,8 +88,22 @@ class ProjectInfo extends React.Component {
         const differenceArray = this.diffArray(value, modelLanguageCodes);
         this.setState({ saving: true });
         // newSupportedLanguages are used to update DOM state
-        const newSupportedLanguages = modelLanguageCodes.concat(differenceArray);
-        Meteor.call('project.update', { name, _id, defaultLanguage }, wrapMeteorCallback(() => this.createNLUModels(differenceArray, _id, newSupportedLanguages), 'Changes saved'));
+        const newSupportedLanguages = modelLanguageCodes.concat(
+            differenceArray,
+        );
+        Meteor.call(
+            'project.update',
+            { name, _id, defaultLanguage },
+            wrapMeteorCallback((err) => {
+                if (!err) {
+                    this.createNLUModels(
+                        differenceArray,
+                        _id,
+                        newSupportedLanguages,
+                    );
+                }
+            }, 'Changes saved'),
+        );
     };
 
     renderDeleteModelLanguages = () => (
@@ -91,7 +112,8 @@ class ProjectInfo extends React.Component {
             info
             content={
                 <>
-                    To remove a language from the project, go to <strong> NLU &gt; Settings &gt; Delete </strong>.
+                    To remove a language from the project, go to{' '}
+                    <strong> NLU &gt; Settings &gt; Delete </strong>.
                 </>
             }
         />
@@ -104,10 +126,34 @@ class ProjectInfo extends React.Component {
         return (
             <>
                 {ready && (
-                    <AutoForm schema={projectsSchema || projectsSchemaDefault} model={project} onSubmit={updateProject => this.onSave(updateProject, modelLanguages)} disabled={saving}>
-                        <InfoField name='name' label='Name' className='project-name' />
-                        {projectsSchema && projectsSchema.allowsKey('namespace') && <InfoField name='namespace' label='Namespace' disabled />}
-                        {projectsSchema && projectsSchema.allowsKey('apiKey') && <InfoField name='apiKey' label='Botfront API key' disabled />}
+                    <AutoForm
+                        schema={projectsSchema || projectsSchemaDefault}
+                        model={project}
+                        onSubmit={updateProject => this.onSave(updateProject, modelLanguages)
+                        }
+                        disabled={saving}
+                    >
+                        <InfoField
+                            name='name'
+                            label='Name'
+                            className='project-name'
+                        />
+                        {projectsSchema
+                            && projectsSchema.allowsKey('namespace') && (
+                            <InfoField
+                                name='namespace'
+                                label='Namespace'
+                                disabled
+                            />
+                        )}
+                        {projectsSchema
+                            && projectsSchema.allowsKey('apiKey') && (
+                            <InfoField
+                                name='apiKey'
+                                label='Botfront API key'
+                                disabled
+                            />
+                        )}
                         <Form.Field>
                             <label>Languages supported</label>
                             <Dropdown
@@ -120,15 +166,31 @@ class ProjectInfo extends React.Component {
                                 selection
                                 onChange={this.onChange}
                                 options={this.getOptions()}
-                                renderLabel={language => this.renderLabel(language, modelLanguages.map(lang => lang.value))}
+                                renderLabel={language => this.renderLabel(
+                                    language,
+                                    modelLanguages.map(lang => lang.value),
+                                )
+                                }
                                 data-cy='language-selector'
                             />
-                            {!!modelLanguages.length && this.renderDeleteModelLanguages()}
+                            {!!modelLanguages.length
+                                && this.renderDeleteModelLanguages()}
                         </Form.Field>
-                        {!!modelLanguages.length && <SelectField name='defaultLanguage' options={modelLanguages} className='project-default-language' data-cy='default-langauge-selection' />}
+                        {!!modelLanguages.length && (
+                            <SelectField
+                                name='defaultLanguage'
+                                options={modelLanguages}
+                                className='project-default-language'
+                                data-cy='default-langauge-selection'
+                            />
+                        )}
                         <br />
                         <ErrorsField />
-                        <SubmitField className='primary save-project-info-button' value='Save Changes' data-cy='save-changes' />
+                        <SubmitField
+                            className='primary save-project-info-button'
+                            value='Save Changes'
+                            data-cy='save-changes'
+                        />
                     </AutoForm>
                 )}
             </>


### PR DESCRIPTION
Improved the setState and onChange method for the projectInfo component. In the onChange method, now it is verified that the language deleted is not the one in 'saved in the project'