### PR TITLE
Feat/timestamped models

### DIFF
--- a/botfront/docs/guide/developers-guide/README.md
+++ b/botfront/docs/guide/developers-guide/README.md
@@ -39,13 +39,11 @@ The test suite starts by testing the setup process **and will wipe the database*
 
 ## Developing with Docker Compose
 
-Until we provide a better way...
+Follow those instructions to develop Botfront while interacting with all the services via docker-compose:
 
-1. Set the `MODELS_LOCAL_PATH` environment variable in your shell with for example `export MODELS_LOCAL_PATH=~/botfront-projects/s`
-2. Start Botfront locally with `meteor npm start`. Botfront will be available at [http://localhost:3000](http://localhost:3000)
-3. In settings > endpoints: change domain names to `localhost`. Don't change ports
-4. In settings > more settings > docker-compose change API host to `http://host.docker.internal:8080`
-5. Create a Botfront projet with `botfront init`. Don't start it
-6. In `.botfront/botfront.yml`,  set the `bf_project_id` with the project ID of the locally running Botfront
-7. In `.botfront/botfront.yml`, set the `mongo_url` to `mongodb://host.docker.internal:3001/meteor`
-8. Start the Botfront project with `botfront up`
+1. Reset meteor (**this will wipe the database**) with `meteor reset`
+2. Set the `MODELS_LOCAL_PATH` environment variable in your shell with for example `export MODELS_LOCAL_PATH=~/botfront-projects/s`
+3. Start Botfront locally with `meteor npm run start:docker-compose.dev`. Botfront will be available at [http://localhost:3000](http://localhost:3000)
+4. Create a Botfront projet with `botfront init`. Don't start it
+5. In `.botfront/botfront.yml`, set the `mongo_url` to `mongodb://host.docker.internal:3001/meteor`
+6. Start the Botfront project with `botfront up`

--- a/botfront/imports/api/endpoints/endpoints.docker-compose.js
+++ b/botfront/imports/api/endpoints/endpoints.docker-compose.js
@@ -6,12 +6,12 @@ export const getDefaultEndpoints = ({ _id }) => {
     const fields = {
         'settings.private.defaultEndpoints': 1,
         'settings.private.bfApiHost': 1,
+        'settings.private.actionsServerUrl': 1,
     };
-
-    const actionsUrl = process.env.ACTIONS_URL ? process.env.ACTIONS_URL : 'http://botfront-actions:5055/webhook';
-    const { settings: { private: { defaultEndpoints = '', bfApiHost } = {} } = {} } = GlobalSettings.findOne({}, { fields });
+    const { settings: { private: { defaultEndpoints = '', bfApiHost, actionsServerUrl } = {} } = {} } = GlobalSettings.findOne({}, { fields });
+    
     return defaultEndpoints
         .replace(/{BF_API_HOST}/g, bfApiHost)
         .replace(/{BF_PROJECT_ID}/g, _id)
-        .replace(/{ACTIONS_URL}/g, actionsUrl);
+        .replace(/{ACTIONS_URL}/g, process.env.ACTIONS_URL || actionsServerUrl);
 };

--- a/botfront/imports/api/globalSettings/globalSettings.schema.default.js
+++ b/botfront/imports/api/globalSettings/globalSettings.schema.default.js
@@ -4,7 +4,9 @@ import SimpleSchema from 'simpl-schema';
 import { validateYaml } from '../../lib/utils';
 
 export const privateSettingsSchema = new SimpleSchema({
-    defaultEndpoints: { type: String, custom: validateYaml, optional: true, defaultValue: '' },
+    defaultEndpoints: {
+        type: String, custom: validateYaml, optional: true, defaultValue: '',
+    },
     defaultCredentials: { type: String, custom: validateYaml, optional: true },
     defaultRules: { type: String, custom: validateYaml, optional: true },
     defaultPolicies: { type: String, custom: validateYaml, optional: true },
@@ -13,7 +15,9 @@ export const privateSettingsSchema = new SimpleSchema({
 
 export const publicSettingsSchema = new SimpleSchema({
     reCatpchaSiteKey: { type: String, optional: true },
-    defaultNLUConfig: { type: String, custom: validateYaml, optional: true, defaultValue: '' },
+    defaultNLUConfig: {
+        type: String, custom: validateYaml, optional: true, defaultValue: '',
+    },
     chitChatProjectId: { type: String, optional: true },
     docUrl: { type: String, defaultValue: 'https://docs.botfront.io' },
     backgroundImages: { type: Array, defaultValue: [] },

--- a/botfront/imports/api/globalSettings/globalSettings.schema.docker-compose.js
+++ b/botfront/imports/api/globalSettings/globalSettings.schema.docker-compose.js
@@ -3,6 +3,8 @@ import { privateSettingsSchema as basePrivateSettingsSchema, publicSettingsSchem
 
 export const privateSettingsSchema = basePrivateSettingsSchema.extend({
     bfApiHost: { type: String, optional: true },
+    actionsServerUrl: { type: String, optional: true },
+    rasaUrl: { type: String, optional: true },
 });
 
 export const GlobalSettingsSchema = new SimpleSchema(

--- a/botfront/imports/api/instances/instances.docker-compose.js
+++ b/botfront/imports/api/instances/instances.docker-compose.js
@@ -1,9 +1,14 @@
 
+import { GlobalSettings } from '../globalSettings/globalSettings.collection';
+
 export const getDefaultInstance = ({ _id }) => {
+
     if (!Meteor.isServer) throw Meteor.Error(401, 'Not Authorized');
+    const settings = GlobalSettings.findOne({ _id: 'SETTINGS' }, { fields: { 'settings.private.rasaUrl': 1 } });
+    const { settings: { private: { rasaUrl } } } = settings;
     return {
         name: 'Default Instance',
-        host: 'http://rasa:5005',
+        host: rasaUrl || 'http://rasa:5005',
         projectId: _id,
     };
 };

--- a/botfront/imports/api/setup.js
+++ b/botfront/imports/api/setup.js
@@ -85,8 +85,11 @@ if (Meteor.isServer) {
             check(accountData, Object);
             check(consent, Boolean);
 
-            const spec = process.env.ORCHESTRATOR ? `.${process.env.ORCHESTRATOR}` : '.docker-compose';
-
+            let spec = process.env.ORCHESTRATOR ? `.${process.env.ORCHESTRATOR}` : '.docker-compose';
+            const devMode = !!process.env.DEV_MODE;
+            if (devMode) {
+                spec = `${spec}.dev`;
+            }
             let globalSettings = null;
 
             try {

--- a/botfront/imports/lib/utils.js
+++ b/botfront/imports/lib/utils.js
@@ -96,7 +96,9 @@ export const getProjectModelFileName = (projectId, extension = null) => {
     return extension ? `${modelName}.${extension}` : modelName;
 };
 
-export const getProjectModelLocalPath = projectId => path.join(process.env.MODELS_LOCAL_PATH || '/app/models', getProjectModelFileName(projectId, 'tar.gz'));
+export const getProjectModelLocalFolder = () => process.env.MODELS_LOCAL_PATH || '/app/models';
+
+export const getProjectModelLocalPath = projectId => path.join(getProjectModelLocalFolder(), getProjectModelFileName(projectId, 'tar.gz'));
 
 export const formatMessage = (message) => {
     const bits = message.split('*');

--- a/botfront/imports/ui/components/admin/settings/Settings.docker-compose.jsx
+++ b/botfront/imports/ui/components/admin/settings/Settings.docker-compose.jsx
@@ -8,6 +8,8 @@ export default [
         render: () => (
             <Tab.Pane>
                 <InfoField name='settings.private.bfApiHost' label='Botfront API host' fontSize={12} />
+                <InfoField name='settings.private.actionsServerUrl' label='Action server base URL' fontSize={12} />
+                <InfoField name='settings.private.rasaUrl' label='rasa server URL' fontSize={12} />
             </Tab.Pane>
         ),
     },

--- a/botfront/imports/ui/components/setup/SetupSteps.jsx
+++ b/botfront/imports/ui/components/setup/SetupSteps.jsx
@@ -58,7 +58,8 @@ class SetupSteps extends React.Component {
                             .then((responses) => {
                                 router.push(`/project/${responses[0]}/nlu/models`);
                             })
-                            .catch(() => {
+                            .catch((e) => {
+                                console.log(e)
                                 router.push({
                                     pathname: '/admin/projects',
                                     state: {

--- a/botfront/package.json
+++ b/botfront/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "meteor run",
-    "start:docker-compose": "ORCHESTRATOR=docker-compose meteor run",
+    "start:docker-compose": "BF_PROJECT_ID=bf ORCHESTRATOR=docker-compose meteor run",
+    "start:docker-compose.dev": "DEV_MODE=true BF_PROJECT_ID=bf ORCHESTRATOR=docker-compose meteor run",
     "debug": "meteor run --inspect-brk=9229",
     "cy:run": "CYPRESS_RETRIES=2 npx cypress run",
     "docs:dev": "npx vuepress dev docs",

--- a/botfront/private/default-settings.docker-compose.dev.json
+++ b/botfront/private/default-settings.docker-compose.dev.json
@@ -8,9 +8,9 @@
             ]
         },
         "private": {
-            "rasaUrl": "http://rasa:5005",
-            "bfApiHost": "http://botfront-api:8080",
-            "actionsServerUrl": "http://actions:5055/webhook",
+            "rasaUrl": "http://localhost:5005",
+            "bfApiHost": "http://localhost:8080",
+            "actionsServerUrl": "http://localhost:5055/webhook",
             "defaultEndpoints": "nlg:\n  url: '{BF_API_HOST}/project/{BF_PROJECT_ID}/nlg'\naction_endpoint:\n  url: '{ACTIONS_URL}'\ntracker_store:\n  store_type: rasa_addons.core.tracker_stores.AnalyticsTrackerStore\n  url: '{BF_API_HOST}'\n  project_id: '{BF_PROJECT_ID}'",
             "defaultCredentials": "rasa_addons.core.channels.webchat.WebchatInput:\n  session_persistence: true\n  base_url: http://localhost:5005\n  socket_path: '/socket.io/'",
             "defaultPolicies": "policies:\n  - name: KerasPolicy\n    epochs: 200\n  - name: FallbackPolicy\n  - name: MemoizationPolicy"

--- a/cli/project-template/.botfront/botfront.yml
+++ b/cli/project-template/.botfront/botfront.yml
@@ -2,7 +2,7 @@ images:
   default:
     botfront: botfront/botfront:v0.15.0
     botfront-api: botfront/botfront-api:v0.15.1
-    rasa: botfront/rasa-for-botfront:v1.1.4-bf.2
+    rasa: botfront/rasa-for-botfront:v1.1.5-bf.1
     duckling: botfront/duckling:latest
     mongo: mongo:latest
     actions: botfront/actions-sdk:latest


### PR DESCRIPTION
A couple of things here:

1.  Use the filename returned in headers from training to save and upload the model. But we're still setting a fixed_model_name, so the functionality should remain unchanged
2. A default settings file to have Meteor working with the docker-compose stack out of the box
3. A npm script to start Botfront in that friendly developer mode (it should may be set MONGO_URL to mongodb://localhost:27017/bf
4. Developer guide updated

