### PR TITLE
feat(context-helper): add entities and intent generation function

### DIFF
--- a/botfront/cypress/integration/03-stories/stories.spec.js
+++ b/botfront/cypress/integration/03-stories/stories.spec.js
@@ -168,11 +168,11 @@ describe('stories', function() {
             .type('{backspace}{backspace}{backspace}{enter}');
         cy.contains('storyGroup').should('exist');
         // Initially none of the story groups are selected, therefore content in the train button should be 'Train'
-        cy.contains('Train Everything');
+        cy.contains('Train everything');
         cy.get('.active > #not-selected').click({ force: true });
         cy.get('#not-selected').click({ force: true });
         // Text in the train button should change after all the stories are selected
-        cy.contains('Partial Training');
+        cy.contains('Partial training');
 
         cy.contains('storyGroup').click({ force: true });
         cy.dataCy('delete-story').click({ force: true });

--- a/botfront/cypress/integration/nlu_models/trainbutton.spec.js
+++ b/botfront/cypress/integration/nlu_models/trainbutton.spec.js
@@ -20,7 +20,7 @@ describe('Train Button', function() {
         cy.contains('storyGroupOne').click();
         // Selecting a story group
         cy.get('.active > #not-selected').click();
-        cy.contains('Partial Training');
+        cy.contains('Partial training');
         cy.dataCy('train-button').trigger('mouseover');
         cy.contains('Train NLU and stories from 1 focused story group.');
         cy.visit('/project/bf/nlu/models');

--- a/botfront/imports/api/project/project.methods.js
+++ b/botfront/imports/api/project/project.methods.js
@@ -176,5 +176,16 @@ if (Meteor.isServer) {
                 throw error;
             }
         },
+
+        async 'project.getSlots'(projectId) {
+            check(projectId, String);
+
+            try {
+                const slots = await Meteor.callWithPromise('slots.getSlots', projectId);
+                return slots;
+            } catch (error) {
+                throw error;
+            }
+        },
     });
 }

--- a/botfront/imports/api/project/project.methods.test.js
+++ b/botfront/imports/api/project/project.methods.test.js
@@ -1,0 +1,118 @@
+import { Meteor } from 'meteor/meteor';
+import { expect } from 'chai';
+// eslint-disable-next-line import/named
+import { extractDomainFromStories, extractData } from './project.methods';
+
+const stories = [
+    {
+        _id: 'oozR82KYZdwF9PL6G',
+        story: '* get_started\n    - utter_get_started',
+        title: 'Get started',
+        storyGroupId: 'McySETYSgRHr5qRif',
+        projectId: 'bf',
+    },
+    {
+        _id: 'aqoo6S9wfjo5Z85gW',
+        story: '* test_intent{"entity1": "value1"}\n    - utter_test_intent',
+        title: 'Intro stories 2',
+        projectId: 'bf',
+        storyGroupId: 'McySETYSgRHr5qRif',
+    },
+];
+
+const models = [
+    {
+        _id: 'jBEFEmL4X33Y6op49',
+        training_data: {
+            common_examples: [
+                {
+                    text: 'human now',
+                    intent: 'basics.request_handover',
+                    entities: [{
+                        start: 0, end: 5, value: 'human', entity: 'human',
+                    }],
+                    _id: '0e6e7175-6718-42ee-a033-55fb96aeacdb',
+                },
+                {
+                    text: 'cancel',
+                    intent: 'basics.time',
+                    entities: [{
+                        start: 0, end: 6, value: 'cancel', entity: 'time',
+                    }],
+                    _id: '0e6e7175-6718-42ee-a033-55fb96aeacdb',
+                },
+            ],
+            entity_synonyms: [],
+            regex_features: [],
+            fuzzy_gazette: [],
+        },
+    },
+
+    {
+        _id: 'jBEFEmL4X33Y6op49',
+        training_data: {
+            common_examples: [
+                {
+                    text: 'this is an actual test',
+                    intent: 'basics.test',
+                    entities: [{
+                        start: 18, end: 23, value: 'test', entity: 'test',
+                    }],
+                    _id: '0e6e7175-6718-42ee-a033-55fb96aeacdb',
+                },
+            ],
+            entity_synonyms: [],
+            regex_features: [],
+            fuzzy_gazette: [],
+        },
+    },
+];
+
+const emptyTrainingData = [
+    {
+        _id: 'jBEFEmL4X33Y6op49',
+        training_data: {
+            common_examples: [],
+            entity_synonyms: [],
+            regex_features: [],
+            fuzzy_gazette: [],
+        },
+    },
+    {
+        _id: 'jBEFEmL4X33Y6op49',
+        training_data: {
+            common_examples: [],
+            entity_synonyms: [],
+            regex_features: [],
+            fuzzy_gazette: [],
+        },
+    },
+];
+
+if (Meteor.isTest) {
+    describe('entities and intents extraction test', function() {
+        if (Meteor.isServer) {
+            it('extract intent and entities from stories', function() {
+                const { intents, entities } = extractDomainFromStories(
+                    stories.map(story => story.story),
+                );
+                expect(intents).to.deep.equal(new Set(['get_started', 'test_intent']));
+                expect(entities).to.deep.equal(new Set(['entity1']));
+            });
+
+            it('extraction from training data, case with multiple models, and multiple entities and intents', function() {
+                const { intents, entities } = extractData(models);
+                expect(intents).to.deep.equal(
+                    new Set(['basics.time', 'basics.request_handover', 'basics.test']),
+                );
+                expect(entities).to.deep.equal(new Set(['human', 'time', 'test']));
+            });
+
+            it('should not crash when training data is empty', function() {
+                const { intents, entities } = extractData(emptyTrainingData);
+                expect(intents).to.deep.equal(new Set([]));
+                expect(entities).to.deep.equal(new Set([]));
+            });
+        }
+    });
+}

--- a/botfront/imports/api/slots/slots.methods.js
+++ b/botfront/imports/api/slots/slots.methods.js
@@ -45,4 +45,9 @@ Meteor.methods({
         validateSchema(slot);
         return Slots.remove(slot);
     },
+
+    'slots.getSlots'(projectId) {
+        check(projectId, String);
+        return Slots.find({ projectId }).fetch();
+    },
 });

--- a/botfront/imports/api/story/stories.methods.js
+++ b/botfront/imports/api/story/stories.methods.js
@@ -18,4 +18,14 @@ Meteor.methods({
         check(story, Object);
         return Stories.remove(story);
     },
+
+    'stories.getStories'(projectId) {
+        check(projectId, String);
+        return Stories.find({ projectId }).fetch();
+    },
 });
+
+export const getStories = async (projectId) => {
+    const result = await Meteor.callWithPromise('stories.getStories', projectId);
+    return result;
+};

--- a/botfront/imports/api/story/stories.methods.js
+++ b/botfront/imports/api/story/stories.methods.js
@@ -24,8 +24,3 @@ Meteor.methods({
         return Stories.find({ projectId }).fetch();
     },
 });
-
-export const getStories = async (projectId) => {
-    const result = await Meteor.callWithPromise('stories.getStories', projectId);
-    return result;
-};

--- a/botfront/imports/ui/components/utils/TrainButton.jsx
+++ b/botfront/imports/ui/components/utils/TrainButton.jsx
@@ -29,7 +29,7 @@ class TrainButton extends React.Component {
             <Button
                 color='blue'
                 icon='grid layout'
-                content='Train Everything'
+                content='Train everything'
                 labelPosition='left'
                 disabled={isTraining(project) || !instance}
                 loading={isTraining(project)}
@@ -44,7 +44,7 @@ class TrainButton extends React.Component {
                     <Button
                         color='yellow'
                         icon='eye'
-                        content='Partial Training'
+                        content='Partial training'
                         labelPosition='left'
                         disabled={isTraining(project) || !instance}
                         loading={isTraining(project)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,3 @@
 {
-  "lockfileVersion": 1,
-  "version": "0.15.0-rc.1"
+  "lockfileVersion": 1
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,4 @@
 {
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "version": "0.15.0-rc.1"
 }


### PR DESCRIPTION
This function extracts entities and intents from training data and the stories, which will be used by the Context API to pass values to the individual components

Test cases:
1. No stories present
2. common_examples empty in the training data
3. only one model present with multiple combination of entities
4. Multiple models with combination of multiple entities [no entities, same entity present at multiple places at different places, different entities present at different places]


