### PR TITLE
Move intro stories

### DIFF
--- a/botfront/cypress/integration/stories/default_story_group.spec.js
+++ b/botfront/cypress/integration/stories/default_story_group.spec.js
@@ -44,6 +44,7 @@ describe('default story creation ', () => {
             .click();
 
         // there should be no additional stories in default stories
-        // cy.get('[data-cy=story-editor]').should('not.exist');
+        cy.get('[data-cy=browser-item]')
+            .should('not.exist');
     });
 });

--- a/botfront/cypress/integration/stories/stories.spec.js
+++ b/botfront/cypress/integration/stories/stories.spec.js
@@ -206,6 +206,7 @@ describe('stories', function() {
 
     it('should be able to delete and add stories in intro stories', function() {
         cy.visit('/project/bf/stories');
+        cy.dataCy('intro-story-group').click({ force: true });
         cy.dataCy('story-editor').get('textarea');
         cy.dataCy('add-story').click({ force: true });
         cy.dataCy('story-editor').should('have.lengthOf', 2);
@@ -216,6 +217,7 @@ describe('stories', function() {
         cy.dataCy('story-editor').should('have.lengthOf', 1);
         cy.dataCy('delete-story').click({ force: true });
         cy.dataCy('confirm-yes').click({ force: true });
+        cy.dataCy('intro-story-group').should('exist');
         cy.dataCy('add-story').click({ force: true });
         cy.dataCy('story-editor').should('have.lengthOf', 1);
     });

--- a/botfront/imports/ui/components/common/Browser.jsx
+++ b/botfront/imports/ui/components/common/Browser.jsx
@@ -86,6 +86,7 @@ class Browser extends React.Component {
 
     render() {
         const {
+            children,
             data,
             index: indexProp,
             pageSize,
@@ -179,6 +180,7 @@ class Browser extends React.Component {
                             data-cy='add-item-input'
                         />
                     ))}
+                {children}
                 {data.length > 0 && (
                     <Menu vertical fluid>
                         {items}
@@ -203,6 +205,7 @@ Browser.propTypes = {
     changeName: PropTypes.func,
     allowEdit: PropTypes.bool,
     placeholderAddItem: PropTypes.string,
+    children: PropTypes.element,
 };
 
 Browser.defaultProps = {
@@ -218,6 +221,7 @@ Browser.defaultProps = {
     selectAccessor: '',
     allowEdit: false,
     placeholderAddItem: '',
+    children: <></>,
 };
 
 export default Browser;

--- a/botfront/imports/ui/components/common/style.import.less
+++ b/botfront/imports/ui/components/common/style.import.less
@@ -15,11 +15,13 @@
     }
 }
 
-.menu.vertical .active.item.selected-blue {
+.menu.vertical {
+    .active.item.selected-blue {
     background-color: rgba(33,133,208,0.08);
     font-weight: bold;
-    &:hover {
-        background-color: rgba(33,133,208,0.16);
+        &:hover {
+            background-color: rgba(33,133,208,0.16);
+        }
     }
 }
 

--- a/botfront/imports/ui/components/stories/IntroStoryMenu.jsx
+++ b/botfront/imports/ui/components/stories/IntroStoryMenu.jsx
@@ -1,0 +1,62 @@
+import {
+    Menu, Icon,
+} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+
+class IntroStoryMenu extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        const {
+            introStory,
+            introClick,
+            introStoryClick,
+            isSelected,
+        } = this.props;
+        return (
+            <Menu
+                vertical
+                fluid
+                onClick={introStoryClick}
+                className={`intro-story ${
+                    isSelected ? 'selected-intro-story' : ''
+                }`}
+            >
+                <Menu.Item
+                    active={isSelected}
+                    link
+                    data-cy='intro-story-group'
+                >
+                    <Icon
+                        id={`${
+                            introStory && introStory.selected
+                                ? 'selected'
+                                : 'not-selected'
+                        }`}
+                        name='eye'
+                        onClick={e => introClick(e, introStory)}
+                    />
+                    <span>Intro stories</span>
+                </Menu.Item>
+            </Menu>
+        );
+    }
+}
+
+IntroStoryMenu.propTypes = {
+    introStory: PropTypes.object.isRequired,
+    introClick: PropTypes.func.isRequired,
+    introStoryClick: PropTypes.func.isRequired,
+    isSelected: PropTypes.bool.isRequired,
+};
+
+IntroStoryMenu.defaultProps = {
+};
+
+
+export default IntroStoryMenu;

--- a/botfront/imports/ui/components/stories/IntroStorySubMenu.jsx
+++ b/botfront/imports/ui/components/stories/IntroStorySubMenu.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 
-class IntroStoryMenu extends React.Component {
+class IntroStorySubMenu extends React.Component {
     constructor(props) {
         super(props);
         this.state = {};
@@ -48,15 +48,15 @@ class IntroStoryMenu extends React.Component {
     }
 }
 
-IntroStoryMenu.propTypes = {
+IntroStorySubMenu.propTypes = {
     introStory: PropTypes.object.isRequired,
     introClick: PropTypes.func.isRequired,
     introStoryClick: PropTypes.func.isRequired,
     isSelected: PropTypes.bool.isRequired,
 };
 
-IntroStoryMenu.defaultProps = {
+IntroStorySubMenu.defaultProps = {
 };
 
 
-export default IntroStoryMenu;
+export default IntroStorySubMenu;

--- a/botfront/imports/ui/components/stories/Stories.jsx
+++ b/botfront/imports/ui/components/stories/Stories.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { setStoryGroup } from '../../store/actions/actions';
 import { wrapMeteorCallback } from '../utils/Errors';
 
-import IntroStoryMenu from './IntroStoryMenu';
+import IntroStorySubMenu from './IntroStorySubMenu';
 import ItemsBrowser from '../common/Browser';
 import StoriesEditor from './StoriesEditor';
 
@@ -288,7 +288,7 @@ class Stories extends React.Component {
                                 changeName={this.handleNameChange}
                                 placeholderAddItem='Choose a group name'
                             >
-                                <IntroStoryMenu
+                                <IntroStorySubMenu
                                     introStory={introStory}
                                     introClick={this.handleIntroClick}
                                     introStoryClick={this.handleIntroStoryClick}

--- a/botfront/imports/ui/components/stories/Stories.jsx
+++ b/botfront/imports/ui/components/stories/Stories.jsx
@@ -248,23 +248,6 @@ class Stories extends React.Component {
         return (
             <Grid className='stories-container'>
                 <Grid.Row columns={2}>
-                    <Grid.Column width={12} className='story-name-parent'>
-                        {storySelected !== -1 ? (
-                            <Message info size='small'>
-                                Create detailed use case scenarios for your bot using
-                                multiple stories.
-                            </Message>
-                        ) : (
-                            <Message info size='small'>
-                                The Intro stories group contains the initial messages that
-                                would be sent to users when they start chatting with your
-                                bot.
-                            </Message>
-                        )}
-                    </Grid.Column>
-                </Grid.Row>
-
-                <Grid.Row columns={2}>
                     <Grid.Column width={4}>
                         {validationErrors && (
                             <Message

--- a/botfront/imports/ui/components/stories/Stories.jsx
+++ b/botfront/imports/ui/components/stories/Stories.jsx
@@ -226,6 +226,50 @@ class Stories extends React.Component {
         );
     };
 
+    renderIntroStoryGroup = () => {
+        const { storyGroups } = this.props;
+        const {
+            storyIndex,
+            storyGroupNameSelected,
+        } = this.state;
+        const introStory = storyGroups.find(storyGroup => storyGroup.introStory);
+        const storyGroupFiltered = storyGroups
+            .filter(storyGroup => !storyGroup.introStory)
+            .sort(this.sortAlphabetically);
+        const storySelected = this.storyGroupSelected(
+            storyIndex,
+            storyGroupNameSelected,
+            storyGroupFiltered,
+        );
+        return (
+            <Menu
+                vertical
+                fluid
+                onClick={this.handleIntroStoryClick}
+                className={`intro-story ${
+                    storySelected === -1 ? 'selected-intro-story' : ''
+                }`}
+            >
+                <Menu.Item
+                    active={storySelected === -1}
+                    link
+                    data-cy='intro-story-group'
+                >
+                    <Icon
+                        id={`${
+                            introStory && introStory.selected
+                                ? 'selected'
+                                : 'not-selected'
+                        }`}
+                        name='eye'
+                        onClick={e => this.handleIntroClick(e, introStory)}
+                    />
+                    <span>Intro stories</span>
+                </Menu.Item>
+            </Menu>
+        );
+    }
+
     render() {
         const { storyGroups } = this.props;
         const {
@@ -243,37 +287,9 @@ class Stories extends React.Component {
             storyGroupNameSelected,
             storyGroupFiltered,
         );
-
         return (
             <Grid className='stories-container'>
                 <Grid.Row columns={2}>
-                    <Grid.Column width={4}>
-                        <Menu
-                            vertical
-                            fluid
-                            onClick={this.handleIntroStoryClick}
-                            className={`intro-story ${
-                                storySelected === -1 ? 'selected-intro-story' : ''
-                            }`}
-                        >
-                            <Menu.Item
-                                active={storySelected === -1}
-                                link
-                                data-cy='intro-story-group'
-                            >
-                                <Icon
-                                    id={`${
-                                        introStory && introStory.selected
-                                            ? 'selected'
-                                            : 'not-selected'
-                                    }`}
-                                    name='eye'
-                                    onClick={e => this.handleIntroClick(e, introStory)}
-                                />
-                                <span>Intro stories</span>
-                            </Menu.Item>
-                        </Menu>
-                    </Grid.Column>
                     <Grid.Column width={12} className='story-name-parent'>
                         {storySelected !== -1 ? (
                             <Message info size='small'>
@@ -313,7 +329,9 @@ class Stories extends React.Component {
                                 toggleSelect={this.handleStoryGroupSelect}
                                 changeName={this.handleNameChange}
                                 placeholderAddItem='Choose a group name'
-                            />
+                            >
+                                {this.renderIntroStoryGroup()}
+                            </ItemsBrowser>
                         )}
                     </Grid.Column>
 

--- a/botfront/imports/ui/components/stories/Stories.jsx
+++ b/botfront/imports/ui/components/stories/Stories.jsx
@@ -1,5 +1,5 @@
 import {
-    Grid, Message, Menu, Icon,
+    Grid, Message,
 } from 'semantic-ui-react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -7,6 +7,8 @@ import React from 'react';
 
 import { setStoryGroup } from '../../store/actions/actions';
 import { wrapMeteorCallback } from '../utils/Errors';
+
+import IntroStoryMenu from './IntroStoryMenu';
 import ItemsBrowser from '../common/Browser';
 import StoriesEditor from './StoriesEditor';
 
@@ -225,51 +227,7 @@ class Stories extends React.Component {
             )
         );
     };
-
-    renderIntroStoryGroup = () => {
-        const { storyGroups } = this.props;
-        const {
-            storyIndex,
-            storyGroupNameSelected,
-        } = this.state;
-        const introStory = storyGroups.find(storyGroup => storyGroup.introStory);
-        const storyGroupFiltered = storyGroups
-            .filter(storyGroup => !storyGroup.introStory)
-            .sort(this.sortAlphabetically);
-        const storySelected = this.storyGroupSelected(
-            storyIndex,
-            storyGroupNameSelected,
-            storyGroupFiltered,
-        );
-        return (
-            <Menu
-                vertical
-                fluid
-                onClick={this.handleIntroStoryClick}
-                className={`intro-story ${
-                    storySelected === -1 ? 'selected-intro-story' : ''
-                }`}
-            >
-                <Menu.Item
-                    active={storySelected === -1}
-                    link
-                    data-cy='intro-story-group'
-                >
-                    <Icon
-                        id={`${
-                            introStory && introStory.selected
-                                ? 'selected'
-                                : 'not-selected'
-                        }`}
-                        name='eye'
-                        onClick={e => this.handleIntroClick(e, introStory)}
-                    />
-                    <span>Intro stories</span>
-                </Menu.Item>
-            </Menu>
-        );
-    }
-
+    
     render() {
         const { storyGroups } = this.props;
         const {
@@ -330,7 +288,12 @@ class Stories extends React.Component {
                                 changeName={this.handleNameChange}
                                 placeholderAddItem='Choose a group name'
                             >
-                                {this.renderIntroStoryGroup()}
+                                <IntroStoryMenu
+                                    introStory={introStory}
+                                    introClick={this.handleIntroClick}
+                                    introStoryClick={this.handleIntroStoryClick}
+                                    isSelected={storySelected === -1}
+                                />
                             </ItemsBrowser>
                         )}
                     </Grid.Column>

--- a/botfront/imports/ui/components/stories/style.import.less
+++ b/botfront/imports/ui/components/stories/style.import.less
@@ -58,11 +58,8 @@
 }
 
 .ui.vertical.menu.intro-story {
-  border-color: rgb(33,133,208);
-  border-width: 2px;
-  span {
-    color: rgb(33,133,208);
-  }
+  border-width: 1px;
+  border-radius: 5px;
 }
 
 .story-editor {


### PR DESCRIPTION
<!-- description of what you achieved -->
- I moved the Intro Stories button in the stories group menu into a new file to
- I rearranged the Stories Group Menu to include the IntroStorySubMenu component below the add story button
- I removed the blue tip header when viewing story groups
- I fixed a bug where the selected story group in the story group menu was grey instead of blue

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
