### PR TITLE
fix: do not set docker-compose as default orchestrator

### DIFF
--- a/botfront/imports/api/orchestration/orchestration.methods.js
+++ b/botfront/imports/api/orchestration/orchestration.methods.js
@@ -3,7 +3,7 @@ import { Meteor } from 'meteor/meteor';
 if (Meteor.isServer) {
     Meteor.methods({
         'orchestration.type'() {
-            return process.env.ORCHESTRATOR ? process.env.ORCHESTRATOR : 'docker-compose';
+            return process.env.ORCHESTRATOR ? process.env.ORCHESTRATOR : 'default';
         },
     });
 }

--- a/botfront/imports/api/setup.js
+++ b/botfront/imports/api/setup.js
@@ -85,7 +85,7 @@ if (Meteor.isServer) {
             check(accountData, Object);
             check(consent, Boolean);
 
-            let spec = process.env.ORCHESTRATOR ? `.${process.env.ORCHESTRATOR}` : '.docker-compose';
+            let spec = process.env.ORCHESTRATOR;
             if (process.env.NODE_ENV === 'development') {
                 spec = `${spec}.dev`;
             }
@@ -109,7 +109,7 @@ if (Meteor.isServer) {
             const {
                 email, password, firstName, lastName,
             } = accountData;
-            const userId = Accounts.createUser({
+            Accounts.createUser({
                 email,
                 password,
                 profile: {


### PR DESCRIPTION
Not everyone wants to use docker, by removing using docker-compose as default orchestrator allows to run Botfront without assumptions 