### PR TITLE
Exception handling

### DIFF
--- a/botfront/cypress/integration/stories/story_exceptions.spec.js
+++ b/botfront/cypress/integration/stories/story_exceptions.spec.js
@@ -1,0 +1,149 @@
+/* eslint-disable no-undef */
+
+describe('stories', function() {
+    afterEach(function() {
+        cy.deleteProject('bf');
+    });
+
+    beforeEach(function() {
+        cy.createProject('bf', 'My Project', 'fr').then(() => cy.login());
+    });
+
+    it('should alert the user of errors', function() {
+        cy.visit('/project/bf/stories');
+        cy.wait(200);
+        cy.dataCy('story-group-error-alert').should('not.exist');
+        cy.dataCy('top-menu-error-alert').should('not.exist');
+        cy.get('.ace_line')
+            .first()
+            .click({ force: true })
+            .get('textarea')
+            .eq(0)
+            .clear()
+            .type('test error');
+        cy.dataCy('story-group-error-alert').should('exist');
+        cy.dataCy('top-menu-error-alert').contains('1 Error');
+        cy.dataCy('create-branch')
+            .click({ force: true });
+        cy.wait(100);
+        cy.get('.ace_line')
+            .eq(1)
+            .click({ force: true })
+            .get('textarea')
+            .eq(1)
+            .type('test error');
+        cy.dataCy('story-group-error-alert').should('exist');
+        cy.dataCy('branch-tab-error-alert').should('exist');
+        cy.dataCy('top-menu-error-alert').contains('2 Errors');
+        cy.get('.ace_line')
+            .eq(1)
+            .click({ force: true })
+            .get('textarea')
+            .eq(1)
+            .clear();
+        cy.dataCy('story-group-error-alert').should('exist');
+        cy.dataCy('top-menu-error-alert').contains('1 Error');
+        cy.get('.ace_line')
+            .first()
+            .click({ force: true })
+            .get('textarea')
+            .eq(0)
+            .clear();
+        cy.dataCy('story-group-error-alert').should('not.exist');
+        cy.dataCy('top-menu-error-alert').should('not.exist');
+    });
+
+    it('should remove alerts when a story is deleted', function() {
+        cy.visit('/project/bf/stories');
+        cy.wait(200);
+        cy.dataCy('story-group-error-alert').should('not.exist');
+        cy.dataCy('top-menu-error-alert').should('not.exist');
+        cy.get('.ace_line')
+            .first()
+            .click({ force: true })
+            .get('textarea')
+            .eq(0)
+            .clear()
+            .type('- utter_test')
+            .type('{enter}test error');
+        cy.dataCy('story-group-error-alert').should('exist');
+        cy.dataCy('story-group-warning-alert').should('exist');
+
+        cy.dataCy('add-story')
+            .click({ force: true });
+        cy.dataCy('delete-story')
+            .first()
+            .click({ force: true });
+        cy.dataCy('confirm-yes')
+            .click({ force: true });
+        cy.wait(100);
+        cy.dataCy('story-group-error-alert').should('not.exist');
+        cy.dataCy('story-group-warning-alert').should('not.exist');
+
+        cy.get('.ace_line')
+            .first()
+            .click({ force: true })
+            .get('textarea')
+            .eq(0)
+            .clear()
+            .type('- utter_test')
+            .type('{enter}test error');
+        cy.dataCy('delete-story')
+            .first()
+            .click({ force: true });
+        cy.dataCy('confirm-yes')
+            .click({ force: true });
+        cy.dataCy('story-group-error-alert').should('not.exist');
+        cy.dataCy('story-group-warning-alert').should('not.exist');
+    });
+
+    it('should alert the user of wanings', function() {
+        cy.visit('/project/bf/stories');
+        cy.wait(200);
+        cy.get('.ace_line')
+            .first()
+            .click({ force: true })
+            .get('textarea')
+            .eq(0)
+            .clear();
+        cy.dataCy('story-group-warning-alert').should('not.exist');
+        cy.dataCy('top-menu-warning-alert').should('not.exist');
+        cy.get('.ace_line')
+            .first()
+            .click({ force: true })
+            .get('textarea')
+            .eq(0)
+            .type('- ');
+        cy.dataCy('story-group-warning-alert').should('exist');
+        cy.dataCy('top-menu-warning-alert').contains('1 Warning');
+        cy.dataCy('create-branch')
+            .click({ force: true });
+        cy.wait(100);
+        cy.get('.ace_line')
+            .eq(1)
+            .click({ force: true })
+            .get('textarea')
+            .eq(1)
+            .type('- ');
+        cy.dataCy('story-group-warning-alert').should('exist');
+        cy.dataCy('branch-tab-warning-alert').should('exist');
+        cy.dataCy('top-menu-warning-alert').contains('2 Warnings');
+        cy.get('.ace_line')
+            .eq(1)
+            .click({ force: true })
+            .get('textarea')
+            .eq(1)
+            .clear();
+        cy.dataCy('story-group-warning-alert').should('exist');
+        cy.dataCy('branch-tab-warning-alert').should('not.exist');
+        cy.dataCy('top-menu-warning-alert').contains('1 Warning');
+        cy.get('.ace_line')
+            .first()
+            .click({ force: true })
+            .get('textarea')
+            .eq(0)
+            .clear();
+        cy.dataCy('story-group-warning-alert').should('not.exist');
+        cy.dataCy('top-menu-warning-alert').should('not.exist');
+    });
+});

--- a/botfront/imports/lib/story_controller.js
+++ b/botfront/imports/lib/story_controller.js
@@ -307,6 +307,14 @@ export class StoryController {
         if (this.saveUpdate) this.saveUpdate(this.md, this.getErrors(), this.getWarnings());
     }
 
+    getErrors = () => {
+        return this.exceptions.filter(exception => exception.type === 'error');
+    }
+
+    getWarnings = () => {
+        return this.exceptions.filter(exception => exception.type === 'warning');
+    }
+
     getErrors = () => (
         this.exceptions.filter(exception => exception.type === 'error')
     )

--- a/botfront/imports/ui/components/common/Browser.jsx
+++ b/botfront/imports/ui/components/common/Browser.jsx
@@ -114,7 +114,8 @@ class Browser extends React.Component {
             >
                 {editing !== index ? (
                     <>
-                        <ExceptionAlerts errors={item.hasErrors} warnings={item.hasWarnings} />
+                        {item.hasWarnings.length > 0 ? <Icon name='exclamation circle' color='yellow' /> : <></>}
+                        {item.hasErrors.length > 0 ? <Icon name='times circle' color='red' /> : <></>}
                         {selectAccessor && (
                             <Icon
                                 id={`${

--- a/botfront/imports/ui/components/stories/BranchTabLabel.jsx
+++ b/botfront/imports/ui/components/stories/BranchTabLabel.jsx
@@ -103,10 +103,10 @@ class BranchTabLabel extends React.Component {
         const { exceptions } = this.props;
         const alertList = [];
         if (exceptions.warnings && exceptions.warnings.length > 0) {
-            alertList.push(<Icon key='warning-icon' name='exclamation circle' color='yellow' />);
+            alertList.push(<Icon key='warning-icon' name='exclamation circle' color='yellow' data-cy='branch-tab-warning-alert' />);
         }
         if (exceptions.errors && exceptions.errors.length > 0) {
-            alertList.push(<Icon key='error-icon' name='times circle' color='red' />);
+            alertList.push(<Icon key='error-icon' name='times circle' color='red' data-cy='branch-tab-error-alert' />);
         }
         return <>{alertList}</>;
     };

--- a/botfront/imports/ui/components/stories/ExceptionAlerts.jsx
+++ b/botfront/imports/ui/components/stories/ExceptionAlerts.jsx
@@ -11,7 +11,7 @@ const ExceptionAlerts = (props) => {
             inverted
             size='tiny'
             trigger={
-                <Icon name='times circle' color='red' />
+                <Icon name='times circle' color='red' data-cy='story-group-error-alert' />
             }
         >
             <p className='exception-popup'>This story group contains errors preventing it from being trained.</p>
@@ -24,7 +24,7 @@ const ExceptionAlerts = (props) => {
             size='tiny'
             position='top center'
             trigger={
-                <Icon name='exclamation circle' color='yellow' />
+                <Icon name='exclamation circle' color='yellow' data-cy='story-group-warning-alert' />
             }
         >
             <p className='exception-popup'>This story group contains warnings.</p>

--- a/botfront/imports/ui/components/stories/StoriesEditor.jsx
+++ b/botfront/imports/ui/components/stories/StoriesEditor.jsx
@@ -21,24 +21,25 @@ function StoriesEditor(props) {
     } = props;
 
     function handleStoryDeletion(index) {
+        const isIntroStory = groupNames
+            .filter(({ value }) => value === stories[index].storyGroupId)[0]
+            .text === 'Intro stories';
         Meteor.call(
             'stories.delete',
             stories[index],
             wrapMeteorCallback((err) => {
                 if (!err) {
-                    if (stories.length === 1) {
-                        onDeleteGroup();
-                    } else {
+                    if (stories.length !== 1 || isIntroStory) {
                         Meteor.call(
                             'storyGroups.updateExceptions',
                             {
                                 _id: stories[index].storyGroupId, storyId: stories[index]._id,
                             },
                             wrapMeteorCallback(() => {
-                                
                             }),
                         );
                     }
+                    onDeleteGroup();
                 }
             }),
         );

--- a/botfront/imports/ui/components/stories/StoryEditorContainer.jsx
+++ b/botfront/imports/ui/components/stories/StoryEditorContainer.jsx
@@ -339,7 +339,8 @@ const StoryEditorContainer = ({
                                     }}
                                     onDelete={() => handleDeleteBranch(childPath, branches, index)
                                     }
-                                    exceptions={branchLabelExceptions}
+                                    hasError={branchLabelExceptions ? branchLabelExceptions.errors.length > 0 : false}
+                                    hasWarning={branchLabelExceptions ? branchLabelExceptions.warnings.length > 0 : false}
                                     siblings={branches}
                                 />
                             );

--- a/botfront/imports/ui/components/stories/StoryEditorContainer.jsx
+++ b/botfront/imports/ui/components/stories/StoryEditorContainer.jsx
@@ -339,8 +339,7 @@ const StoryEditorContainer = ({
                                     }}
                                     onDelete={() => handleDeleteBranch(childPath, branches, index)
                                     }
-                                    hasError={branchLabelExceptions ? branchLabelExceptions.errors.length > 0 : false}
-                                    hasWarning={branchLabelExceptions ? branchLabelExceptions.warnings.length > 0 : false}
+                                    exceptions={branchLabelExceptions}
                                     siblings={branches}
                                 />
                             );

--- a/botfront/imports/ui/components/stories/StoryTopMenu.jsx
+++ b/botfront/imports/ui/components/stories/StoryTopMenu.jsx
@@ -61,7 +61,7 @@ const StoryTopMenu = ({
             return <></>;
         }
         return (
-            <Label className='exception-label' color='yellow'>
+            <Label className='exception-label' color='yellow' data-cy='top-menu-warning-alert'>
                 <Icon name='exclamation circle' />
                 {warnings} Warning{pluralize}
             </Label>
@@ -74,7 +74,7 @@ const StoryTopMenu = ({
             return <></>;
         }
         return (
-            <Label className='exception-label' color='red'>
+            <Label className='exception-label' color='red' data-cy='top-menu-error-alert'>
                 <Icon name='times circle' />
                 {errors} Error{pluralize}
             </Label>


### PR DESCRIPTION
<!-- description of what you achieved -->
- fixed a bug where alerts were not removed when deleting the last story in intro stories 

I wrote tests that check if:
- error & warning alerts are added & removed to the story group menu tab, story top menu, and branch tab
- error & warning alerts are removed when a story is deleted
- error & warning alerts are removed when the last intro story is deleted

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
