### PR TITLE
Feat/story group deletion

### DIFF
--- a/botfront/cypress/integration/stories/stories.spec.js
+++ b/botfront/cypress/integration/stories/stories.spec.js
@@ -172,7 +172,8 @@ describe('stories', function() {
             .type(`{selectall}{backspace}${testText}`, { force: true });
         cy.wait(500);
         cy.contains(storyGroupOne).trigger('mouseover');
-        cy.contains(storyGroupOne).find('[data-cy=edit-name-icon]').click({ force: true });
+        cy.contains(storyGroupOne).find('[data-cy=ellipsis-menu]').click({ force: true });
+        cy.contains(storyGroupOne).find('[data-cy=edit-menu]').click({ force: true });
         // Change name of a story group
         cy.get('[data-cy=edit-name] input')
             .click({ force: true })

--- a/botfront/cypress/integration/stories/story_groups.spec.js
+++ b/botfront/cypress/integration/stories/story_groups.spec.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-undef */
+const storyGroupOne = 'storyGroupOne';
+const defaultStories = 'Default stories';
+
+describe('stories', function() {
+    afterEach(function() {
+        cy.deleteProject('bf');
+    });
+
+    beforeEach(function() {
+        cy.createProject('bf', 'My Project', 'fr').then(() => cy.login());
+    });
+    
+    it('should be possible to delete a story group', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('add-item').click({ force: true });
+        cy.dataCy('add-item-input')
+            .find('input')
+            .type(`${storyGroupOne}{enter}`);
+        cy.contains(storyGroupOne).trigger('mouseover');
+        cy.contains(storyGroupOne).find('[data-cy=ellipsis-menu]').click({ force: true });
+        cy.contains(storyGroupOne).find('[data-cy=delete-menu]').click({ force: true });
+        cy.get('.actions > .primary').click({ force: true });
+        cy.dataCy('browser-item')
+            .find('span')
+            .contains(storyGroupOne)
+            .should('not.exist');
+    });
+
+    it('it should not be possible to delete a story group with a story linking to another one', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('add-item').click({ force: true });
+        cy.dataCy('add-item-input')
+            .find('input')
+            .type(`${storyGroupOne}{enter}`);
+        cy.dataCy('stories-linker').click({ force: true });
+        cy.dataCy('stories-linker')
+            .find('div')
+            .children()
+            .first()
+            .click({ force: true });
+        cy.contains(storyGroupOne).trigger('mouseover', { force: true });
+        cy.contains(storyGroupOne).find('[data-cy=ellipsis-menu]').click({ force: true });
+        cy.contains(storyGroupOne).find('[data-cy=delete-menu]').trigger('mouseover', { force: true });
+        cy.get('.popup').should('exist');
+        cy.contains(storyGroupOne).find('[data-cy=delete-menu]').click({ force: true });
+        cy.dataCy('browser-item')
+            .find('span')
+            .contains(storyGroupOne)
+            .should('exist');
+    });
+
+    it('it should not be possible to delete a story group with a story destination story in it', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('add-item').click({ force: true });
+        cy.dataCy('add-item-input')
+            .find('input')
+            .type(`${storyGroupOne}{enter}`);
+        cy.dataCy('stories-linker').click({ force: true });
+        cy.dataCy('stories-linker')
+            .find('div')
+            .children()
+            .first()
+            .click({ force: true });
+        cy.contains(defaultStories).click({ force: true });
+        cy.contains(defaultStories).find('[data-cy=ellipsis-menu]').click({ force: true });
+        cy.contains(defaultStories).find('[data-cy=delete-menu]').trigger('mouseover', { force: true });
+        cy.get('.popup').should('exist');
+        cy.contains(defaultStories).find('[data-cy=delete-menu]').click({ force: true });
+        cy.dataCy('browser-item')
+            .find('span')
+            .contains(defaultStories)
+            .should('exist');
+    });
+});

--- a/botfront/cypress/integration/stories/story_titles.spec.js
+++ b/botfront/cypress/integration/stories/story_titles.spec.js
@@ -69,7 +69,8 @@ describe('story title editing', function() {
 
     it('should have consistant behaviour', function() {
         cy.visit('/project/bf/stories');
-        cy.dataCy('edit-name-icon').click({ force: true });
+        cy.dataCy('ellipsis-menu').click({ force: true });
+        cy.dataCy('edit-menu').click({ force: true });
         cy.dataCy('edit-name')
             .find('input')
             .clear()
@@ -79,7 +80,8 @@ describe('story title editing', function() {
             .contains(editedGroupOne)
             .should('exist');
 
-        cy.dataCy('edit-name-icon').click({ force: true });
+        cy.dataCy('ellipsis-menu').click({ force: true });
+        cy.dataCy('edit-menu').click({ force: true });
         cy.dataCy('edit-name')
             .find('input')
             .clear()
@@ -90,7 +92,8 @@ describe('story title editing', function() {
             .contains(editedGroupTwo)
             .should('exist');
 
-        cy.dataCy('edit-name-icon').click({ force: true });
+        cy.dataCy('ellipsis-menu').click({ force: true });
+        cy.dataCy('edit-menu').click({ force: true });
         cy.dataCy('edit-name')
             .find('input')
             .clear()

--- a/botfront/imports/api/storyGroups/storyGroups.methods.js
+++ b/botfront/imports/api/storyGroups/storyGroups.methods.js
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 
 import { StoryGroups } from './storyGroups.collection';
+import { Stories } from '../story/stories.collection';
 
 export const createIntroStoryGroup = (projectId) => {
     if (!Meteor.isServer) throw Meteor.Error(401, 'Not Authorized');
@@ -68,7 +69,7 @@ function handleError(e) {
 Meteor.methods({
     'storyGroups.delete'(storyGroup) {
         check(storyGroup, Object);
-        return StoryGroups.remove(storyGroup);
+        return Stories.remove({ storyGroupId: storyGroup._id }) && StoryGroups.remove(storyGroup);
     },
 
     'storyGroups.insert'(storyGroup) {

--- a/botfront/imports/api/storyGroups/storyGroups.methods.js
+++ b/botfront/imports/api/storyGroups/storyGroups.methods.js
@@ -69,7 +69,7 @@ function handleError(e) {
 Meteor.methods({
     'storyGroups.delete'(storyGroup) {
         check(storyGroup, Object);
-        return Stories.remove({ storyGroupId: storyGroup._id }) && StoryGroups.remove(storyGroup);
+        return StoryGroups.remove(storyGroup) && Stories.remove({ storyGroupId: storyGroup._id }); 
     },
 
     'storyGroups.insert'(storyGroup) {

--- a/botfront/imports/api/storyGroups/storyGroups.methods.js
+++ b/botfront/imports/api/storyGroups/storyGroups.methods.js
@@ -69,7 +69,7 @@ function handleError(e) {
 Meteor.methods({
     'storyGroups.delete'(storyGroup) {
         check(storyGroup, Object);
-        return StoryGroups.remove(storyGroup) && Stories.remove({ storyGroupId: storyGroup._id }); 
+        return StoryGroups.remove(storyGroup) && Stories.remove({ storyGroupId: storyGroup._id });
     },
 
     'storyGroups.insert'(storyGroup) {

--- a/botfront/imports/ui/components/common/Browser.jsx
+++ b/botfront/imports/ui/components/common/Browser.jsx
@@ -1,10 +1,10 @@
 import {
-    Menu, Icon, Input, Loader, Button, Confirm,
+    Menu, Icon, Input, Button,
 } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ExceptionAlerts from '../stories/ExceptionAlerts';
-import EllipsisMenu from './EllipsisMenu';
+import StoryGroupItem from './StoryGroupItem';
 
 class Browser extends React.Component {
     constructor(props) {
@@ -15,8 +15,6 @@ class Browser extends React.Component {
             newItemName: '',
             editing: -1,
             itemName: '',
-            deletionModalVisible: false,
-            projectToDelete: {},
         };
     }
 
@@ -82,23 +80,8 @@ class Browser extends React.Component {
         event.stopPropagation();
         const { toggleSelect } = this.props;
         toggleSelect(element);
-    };
-
-    handleEdit = (index, itemName) => {
-        this.setState({ editing: index, itemName });
-    };
-
-
-    handleDelete = (index, project) => {
-        this.setState({ deletionModalVisible: true });
-        this.setState({ projectToDelete: project });
-    }
-
-    removeStoryGroup = (projectToDelete) => {
-        Meteor.call('storyGroups.delete', projectToDelete);
-        this.setState({ deletionModalVisible: false });
-        this.setState({ projectToDelete: {} });
-    }
+    };    
+  
 
     render() {
         const {
@@ -111,77 +94,31 @@ class Browser extends React.Component {
             saving,
             selectAccessor,
             allowEdit,
+            changeName,
             placeholderAddItem,
         } = this.props;
         const {
-            addMode, newItemName, page, editing, itemName, deletionModalVisible, projectToDelete,
+            addMode, newItemName, page,
         } = this.state;
 
         const items = data.map((item, index) => (
-            <Menu.Item
+
+            <StoryGroupItem
                 key={index.toString()}
-                name={item[nameAccessor]}
-                className={indexProp === index ? 'selected-blue' : ''}
-                active={indexProp === index}
-                onClick={() => this.handleClickMenuItem(index)}
-                link={indexProp !== index}
-                data-cy='browser-item'
-            >
-                {editing !== index ? (
-                    <>
-                        {selectAccessor && (
-                            <Icon
-                                id={`${
-                                    item[selectAccessor]
-                                        ? 'selected'
-                                        : 'not-selected'
-                                }`}
-                                name='eye'
-                                onClick={e => this.handleToggle(e, item)}
-                            />
-                        )}
-                        {<EllipsisMenu
-                            handleEdit={() => this.handleEdit(index, item[nameAccessor])}
-                            handleDelete={() => this.handleDelete(index, item)}
-                        />}
-                        { /* allowEdit && (
-                            <Icon
-                                id='edit-icon'
-                                name='edit'
-                                onClick={() => this.handleEdit(index, item[nameAccessor])
-                                }
-                                data-cy='edit-name-icon'
-                            />
-                            ) */}
-                        <span className='story-group-menu-item'>{item[nameAccessor]}</span>
-                        {indexProp === index && saving && (
-                            <Loader active size='tiny' />
-                        )}
-                    </>
-                ) : (
-                    <Input
-                        onChange={this.handleChangeOldName}
-                        value={itemName}
-                        onKeyDown={e => this.handleKeyDownInput(e, item)}
-                        autoFocus
-                        onBlur={() => this.submitTitleInput(item)}
-                        fluid
-                        data-cy='edit-name'
-                    />
-                )}
-            </Menu.Item>
+                index={index}
+                item={item}
+                indexProp={indexProp}
+                nameAccessor={nameAccessor}
+                handleClickMenuItem={() => this.handleClickMenuItem(index)}
+                selectAccessor={selectAccessor}
+                allowEdit={allowEdit}
+                handleToggle={e => this.handleToggle(e, item)}
+                saving={saving}
+                changeName={changeName}
+            />
         ));
         return (
             <>
-                <Confirm
-                    open={deletionModalVisible}
-                    className='warning'
-                    header='Warning!'
-                    confirmButton='Delete'
-                    content={`The story group ${projectToDelete.name} and all its stories in it will be deleted. This action cannot be undone.`}
-                    onCancel={() => this.setState({ deletionModalVisible: false })}
-                    onConfirm={() => this.removeStoryGroup(projectToDelete)}
-                />
                 {allowAddition
                     && (!addMode ? (
                         <Button

--- a/botfront/imports/ui/components/common/Browser.jsx
+++ b/botfront/imports/ui/components/common/Browser.jsx
@@ -4,6 +4,7 @@ import {
 import PropTypes from 'prop-types';
 import React from 'react';
 import ExceptionAlerts from '../stories/ExceptionAlerts';
+import EllipsisMenu from './EllipsisMenu';
 
 class Browser extends React.Component {
     constructor(props) {
@@ -125,7 +126,8 @@ class Browser extends React.Component {
                                 onClick={e => this.handleToggle(e, item)}
                             />
                         )}
-                        {allowEdit && (
+                        {<EllipsisMenu />}
+                        { /* allowEdit && (
                             <Icon
                                 id='edit-icon'
                                 name='edit'
@@ -133,7 +135,7 @@ class Browser extends React.Component {
                                 }
                                 data-cy='edit-name-icon'
                             />
-                        )}
+                            ) */}
                         <span className='story-group-menu-item'>{item[nameAccessor]}</span>
                         {indexProp === index && saving && (
                             <Loader active size='tiny' />

--- a/botfront/imports/ui/components/common/Browser.jsx
+++ b/botfront/imports/ui/components/common/Browser.jsx
@@ -1,5 +1,5 @@
 import {
-    Menu, Icon, Input, Loader, Button,
+    Menu, Icon, Input, Loader, Button, Confirm,
 } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -15,6 +15,8 @@ class Browser extends React.Component {
             newItemName: '',
             editing: -1,
             itemName: '',
+            deletionModalVisible: false,
+            projectToDelete: {},
         };
     }
 
@@ -86,6 +88,18 @@ class Browser extends React.Component {
         this.setState({ editing: index, itemName });
     };
 
+
+    handleDelete = (index, project) => {
+        this.setState({ deletionModalVisible: true });
+        this.setState({ projectToDelete: project });
+    }
+
+    removeStoryGroup = (projectToDelete) => {
+        Meteor.call('storyGroups.delete', projectToDelete);
+        this.setState({ deletionModalVisible: false });
+        this.setState({ projectToDelete: {} });
+    }
+
     render() {
         const {
             children,
@@ -100,7 +114,7 @@ class Browser extends React.Component {
             placeholderAddItem,
         } = this.props;
         const {
-            addMode, newItemName, page, editing, itemName,
+            addMode, newItemName, page, editing, itemName, deletionModalVisible, projectToDelete,
         } = this.state;
 
         const items = data.map((item, index) => (
@@ -126,7 +140,10 @@ class Browser extends React.Component {
                                 onClick={e => this.handleToggle(e, item)}
                             />
                         )}
-                        {<EllipsisMenu />}
+                        {<EllipsisMenu
+                            handleEdit={() => this.handleEdit(index, item[nameAccessor])}
+                            handleDelete={() => this.handleDelete(index, item)}
+                        />}
                         { /* allowEdit && (
                             <Icon
                                 id='edit-icon'
@@ -156,6 +173,15 @@ class Browser extends React.Component {
         ));
         return (
             <>
+                <Confirm
+                    open={deletionModalVisible}
+                    className='warning'
+                    header='Warning!'
+                    confirmButton='Delete'
+                    content={`The story group ${projectToDelete.name} and all its stories in it will be deleted. This action cannot be undone.`}
+                    onCancel={() => this.setState({ deletionModalVisible: false })}
+                    onConfirm={() => this.removeStoryGroup(projectToDelete)}
+                />
                 {allowAddition
                     && (!addMode ? (
                         <Button

--- a/botfront/imports/ui/components/common/Browser.jsx
+++ b/botfront/imports/ui/components/common/Browser.jsx
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ExceptionAlerts from '../stories/ExceptionAlerts';
 import StoryGroupItem from './StoryGroupItem';
+import { ConversationOptionsContext } from '../utils/Context';
+
 
 class Browser extends React.Component {
     constructor(props) {
@@ -95,6 +97,7 @@ class Browser extends React.Component {
             selectAccessor,
             allowEdit,
             changeName,
+            stories,
             placeholderAddItem,
         } = this.props;
         const {
@@ -115,6 +118,7 @@ class Browser extends React.Component {
                 handleToggle={e => this.handleToggle(e, item)}
                 saving={saving}
                 changeName={changeName}
+                stories={stories}
             />
         ));
         return (
@@ -171,6 +175,7 @@ Browser.propTypes = {
     allowEdit: PropTypes.bool,
     placeholderAddItem: PropTypes.string,
     children: PropTypes.element,
+    stories: PropTypes.array.isRequired,
 };
 
 Browser.defaultProps = {
@@ -189,4 +194,14 @@ Browser.defaultProps = {
     children: <></>,
 };
 
-export default Browser;
+
+export default props => (
+    <ConversationOptionsContext.Consumer>
+        {value => (
+            <Browser
+                {...props}
+                stories={value.stories}
+            />
+        )}
+    </ConversationOptionsContext.Consumer>
+);

--- a/botfront/imports/ui/components/common/EllipsisMenu.jsx
+++ b/botfront/imports/ui/components/common/EllipsisMenu.jsx
@@ -1,20 +1,38 @@
 import React from 'react';
 import {
-    Dropdown,
+    Dropdown, Popup,
 } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 
 function EllipsisMenu(props) {
-    const { handleEdit, handleDelete } = props;
+    const {
+        handleEdit, handleDelete, onClick, deletable,
+    } = props;
     return (
         <Dropdown
             id='ellipsis-icon'
             icon='ellipsis vertical'
             compact
+            direction='left'
+
+            onClick={() => onClick()}
         >
             <Dropdown.Menu id='ellipsis-menu'>
                 <Dropdown.Item onClick={handleEdit}>Edit</Dropdown.Item>
-                <Dropdown.Item onClick={handleDelete}>Delete</Dropdown.Item>
+                {/* the disabling of the delete menu is handled with css, disabling it with the props cause the */}
+                <Popup
+                    content='There are stories linking to this group or stories from this group are linked to others stories'
+                    disabled={deletable}
+                    position='bottom left'
+                    trigger={(
+                        <Dropdown.Item
+                            onClick={deletable ? handleDelete : null}
+                            id={deletable ? '' : 'deleteDisabled'}
+                        >
+                            <div>Delete</div>
+                        </Dropdown.Item>
+                    )}
+                />
             </Dropdown.Menu>
         </Dropdown>
     );
@@ -23,6 +41,8 @@ function EllipsisMenu(props) {
 EllipsisMenu.propTypes = {
     handleEdit: PropTypes.func.isRequired,
     handleDelete: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
+    deletable: PropTypes.bool.isRequired,
 };
 
 

--- a/botfront/imports/ui/components/common/EllipsisMenu.jsx
+++ b/botfront/imports/ui/components/common/EllipsisMenu.jsx
@@ -21,7 +21,7 @@ function EllipsisMenu(props) {
         >
             <Dropdown.Menu id='ellipsis-menu'>
                 <Dropdown.Item data-cy='edit-menu' onClick={handleEdit}>Edit</Dropdown.Item>
-                {/* the disabling of the delete menu is handled with css, disabling it with the props cause the */}
+                {/* the disabling of the delete menu is handled with css, disabling it with the props also disable the popup */}
                 <Popup
                     content='There are stories linking to this group or stories from this group are linked to others stories'
                     disabled={deletable}

--- a/botfront/imports/ui/components/common/EllipsisMenu.jsx
+++ b/botfront/imports/ui/components/common/EllipsisMenu.jsx
@@ -7,18 +7,18 @@ import PropTypes from 'prop-types';
 function EllipsisMenu(props) {
     const { handleEdit, handleDelete } = props;
     return (
-    <Dropdown
-        id='ellipsis-icon'
-        icon='ellipsis vertical'
-        compact
-    >
-        <Dropdown.Menu id='ellipsis-menu'>
+        <Dropdown
+            id='ellipsis-icon'
+            icon='ellipsis vertical'
+            compact
+        >
+            <Dropdown.Menu id='ellipsis-menu'>
                 <Dropdown.Item onClick={handleEdit}>Edit</Dropdown.Item>
                 <Dropdown.Item onClick={handleDelete}>Delete</Dropdown.Item>
-        </Dropdown.Menu>
-    </Dropdown>
-);
-};
+            </Dropdown.Menu>
+        </Dropdown>
+    );
+}
 
 EllipsisMenu.propTypes = {
     handleEdit: PropTypes.func.isRequired,

--- a/botfront/imports/ui/components/common/EllipsisMenu.jsx
+++ b/botfront/imports/ui/components/common/EllipsisMenu.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {
+    Dropdown,
+} from 'semantic-ui-react';
+
+
+export const EllipisMenu = () => (
+    <Dropdown
+        id='ellipsis-icon'
+        icon='ellipsis vertical'
+        compact
+    >
+        <Dropdown.Menu id='ellipsis-menu'>
+            <Dropdown.Item>Edit</Dropdown.Item>
+            <Dropdown.Item>Delete</Dropdown.Item>
+        </Dropdown.Menu>
+    </Dropdown>
+);
+
+
+export default EllipisMenu;

--- a/botfront/imports/ui/components/common/EllipsisMenu.jsx
+++ b/botfront/imports/ui/components/common/EllipsisMenu.jsx
@@ -14,11 +14,13 @@ function EllipsisMenu(props) {
             icon='ellipsis vertical'
             compact
             direction='left'
+            data-cy='ellipsis-menu'
+            
 
             onClick={() => onClick()}
         >
             <Dropdown.Menu id='ellipsis-menu'>
-                <Dropdown.Item onClick={handleEdit}>Edit</Dropdown.Item>
+                <Dropdown.Item data-cy='edit-menu' onClick={handleEdit}>Edit</Dropdown.Item>
                 {/* the disabling of the delete menu is handled with css, disabling it with the props cause the */}
                 <Popup
                     content='There are stories linking to this group or stories from this group are linked to others stories'
@@ -28,6 +30,7 @@ function EllipsisMenu(props) {
                         <Dropdown.Item
                             onClick={deletable ? handleDelete : null}
                             id={deletable ? '' : 'deleteDisabled'}
+                            data-cy='delete-menu'
                         >
                             <div>Delete</div>
                         </Dropdown.Item>

--- a/botfront/imports/ui/components/common/EllipsisMenu.jsx
+++ b/botfront/imports/ui/components/common/EllipsisMenu.jsx
@@ -2,20 +2,28 @@ import React from 'react';
 import {
     Dropdown,
 } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
 
-
-export const EllipisMenu = () => (
+function EllipsisMenu(props) {
+    const { handleEdit, handleDelete } = props;
+    return (
     <Dropdown
         id='ellipsis-icon'
         icon='ellipsis vertical'
         compact
     >
         <Dropdown.Menu id='ellipsis-menu'>
-            <Dropdown.Item>Edit</Dropdown.Item>
-            <Dropdown.Item>Delete</Dropdown.Item>
+                <Dropdown.Item onClick={handleEdit}>Edit</Dropdown.Item>
+                <Dropdown.Item onClick={handleDelete}>Delete</Dropdown.Item>
         </Dropdown.Menu>
     </Dropdown>
 );
+};
+
+EllipsisMenu.propTypes = {
+    handleEdit: PropTypes.func.isRequired,
+    handleDelete: PropTypes.func.isRequired,
+};
 
 
-export default EllipisMenu;
+export default EllipsisMenu;

--- a/botfront/imports/ui/components/common/StoryGroupItem.jsx
+++ b/botfront/imports/ui/components/common/StoryGroupItem.jsx
@@ -25,18 +25,21 @@ function StoryGroupItem(props) {
     const [editing, setEditing] = useState(false);
     const [storyName, setStoryName] = useState(item[nameAccessor]);
     const [deletable, setDeletable] = useState(false);
-
+    
     function checkDeletable() {
+        let originStoriesInTheGroup = false;
         const storiesOfTheGroup = stories
             .filter(story => story.storyGroupId === item._id);
-        const originStories = stories
-            .filter(story => story.checkpoints !== undefined)
-            .map(story => story.checkpoints.map(checkpoint => checkpoint[0]))
-            .flat();
-        const storiesIdsOfTheGroup = storiesOfTheGroup
-            .map(story => story._id);
-        const originStoriesInTheGroup = storiesIdsOfTheGroup.some(storyId => originStories.includes(storyId));
-        const destinationStoriesInTheGroup = storiesOfTheGroup.some(story => story.checkpoint !== undefined);
+        const storiesIdsOfTheGroup = storiesOfTheGroup.map(story => story._id);
+        const storiesWithCheckpoints = stories
+            .filter(story => story.checkpoints !== undefined);
+        if (storiesWithCheckpoints !== []) {
+            let originStories = storiesWithCheckpoints.map(story => story.checkpoints.map(checkpoint => checkpoint[0]));
+            originStories = originStories.flat(); // flatten the array, same as originStories.flat(), but flat is not supported by electron used by cypress
+            originStoriesInTheGroup = storiesIdsOfTheGroup.some(storyId => originStories.includes(storyId));
+        }
+        
+        const destinationStoriesInTheGroup = storiesOfTheGroup.some(story => story.checkpoints !== undefined && story.checkpoints !== []);
 
         setDeletable(!originStoriesInTheGroup && !destinationStoriesInTheGroup);
     }

--- a/botfront/imports/ui/components/common/StoryGroupItem.jsx
+++ b/botfront/imports/ui/components/common/StoryGroupItem.jsx
@@ -24,6 +24,22 @@ function StoryGroupItem(props) {
     const [deletionModalVisible, setDeletionModalVisible] = useState(false);
     const [editing, setEditing] = useState(false);
     const [storyName, setStoryName] = useState(item[nameAccessor]);
+    const [deletable, setDeletable] = useState(false);
+
+    function checkDeletable() {
+        const storiesOfTheGroup = stories
+            .filter(story => story.storyGroupId === item._id);
+        const originStories = stories
+            .filter(story => story.checkpoints !== undefined)
+            .map(story => story.checkpoints.map(checkpoint => checkpoint[0]))
+            .flat();
+        const storiesIdsOfTheGroup = storiesOfTheGroup
+            .map(story => story._id);
+        const originStoriesInTheGroup = storiesIdsOfTheGroup.some(storyId => originStories.includes(storyId));
+        const destinationStoriesInTheGroup = storiesOfTheGroup.some(story => story.checkpoint !== undefined);
+
+        setDeletable(!originStoriesInTheGroup && !destinationStoriesInTheGroup);
+    }
 
     function resetNameEdit() {
         setEditing(false);
@@ -51,7 +67,7 @@ function StoryGroupItem(props) {
         setStoryName(data.value);
     }
 
-    
+
     function removeStoryGroup() {
         Meteor.call('storyGroups.delete', item);
         setDeletionModalVisible(false);
@@ -67,29 +83,31 @@ function StoryGroupItem(props) {
             data-cy='browser-item'
         >
             {!editing ? (
-            <>
-                {selectAccessor && (
-                    <Icon
-                        id={`${
-                            item[selectAccessor]
-                                ? 'selected'
-                                : 'not-selected'
-                        }`}
-                        name='eye'
-                        onClick={e => handleToggle(e, item)}
-                    />
-                )}
-                {allowEdit && (
-                    <EllipsisMenu
-                        handleEdit={() => setEditing(true)}
-                        handleDelete={() => setDeletionModalVisible(true)}
-                    />
-                )}
-                <span className='story-group-menu-item'>{item[nameAccessor]}</span>
-                {indexProp === index && saving && (
-                    <Loader active size='tiny' />
-                )}
-            </>
+                <>
+
+                    {allowEdit && (
+                        <EllipsisMenu
+                            handleEdit={() => setEditing(true)}
+                            handleDelete={() => setDeletionModalVisible(true)}
+                            onClick={() => checkDeletable()}
+                            deletable={deletable}
+                        />
+                    )}{selectAccessor && (
+                        <Icon
+                            id={`${
+                                item[selectAccessor]
+                                    ? 'selected'
+                                    : 'not-selected'
+                            }`}
+                            name='eye'
+                            onClick={e => handleToggle(e, item)}
+                        />
+                    )}
+                    <span className='story-group-menu-item'>{item[nameAccessor]}</span>
+                    {indexProp === index && saving && (
+                        <Loader active size='tiny' />
+                    )}
+                </>
             ) : (
                 <Input
                     onChange={handleNameChange}

--- a/botfront/imports/ui/components/common/StoryGroupItem.jsx
+++ b/botfront/imports/ui/components/common/StoryGroupItem.jsx
@@ -5,7 +5,6 @@ import {
 import PropTypes from 'prop-types';
 import EllipsisMenu from './EllipsisMenu';
 
-
 function StoryGroupItem(props) {
     const {
         index,
@@ -25,21 +24,25 @@ function StoryGroupItem(props) {
     const [editing, setEditing] = useState(false);
     const [storyName, setStoryName] = useState(item[nameAccessor]);
     const [deletable, setDeletable] = useState(false);
-    
+
     function checkDeletable() {
         let originStoriesInTheGroup = false;
-        const storiesOfTheGroup = stories
-            .filter(story => story.storyGroupId === item._id);
+        const storiesOfTheGroup = stories.filter(
+            story => story.storyGroupId === item._id,
+        );
         const storiesIdsOfTheGroup = storiesOfTheGroup.map(story => story._id);
-        const storiesWithCheckpoints = stories
-            .filter(story => story.checkpoints !== undefined);
+        const storiesWithCheckpoints = stories.filter(
+            story => story.checkpoints !== undefined,
+        );
         if (storiesWithCheckpoints !== []) {
             let originStories = storiesWithCheckpoints.map(story => story.checkpoints.map(checkpoint => checkpoint[0]));
             originStories = [].concat(...originStories); // flatten the array, same as originStories.flat(), but flat is not supported by electron used by cypress
             originStoriesInTheGroup = storiesIdsOfTheGroup.some(storyId => originStories.includes(storyId));
         }
-        
-        const destinationStoriesInTheGroup = storiesOfTheGroup.some(story => story.checkpoints !== undefined && story.checkpoints !== []);
+
+        const destinationStoriesInTheGroup = storiesOfTheGroup.some(
+            story => story.checkpoints !== undefined && story.checkpoints !== [],
+        );
 
         setDeletable(!originStoriesInTheGroup && !destinationStoriesInTheGroup);
     }
@@ -70,7 +73,6 @@ function StoryGroupItem(props) {
         setStoryName(data.value);
     }
 
-
     function removeStoryGroup() {
         Meteor.call('storyGroups.delete', item);
         setDeletionModalVisible(false);
@@ -87,7 +89,6 @@ function StoryGroupItem(props) {
         >
             {!editing ? (
                 <>
-
                     {allowEdit && (
                         <EllipsisMenu
                             handleEdit={() => setEditing(true)}
@@ -95,21 +96,16 @@ function StoryGroupItem(props) {
                             onClick={() => checkDeletable()}
                             deletable={deletable}
                         />
-                    )}{selectAccessor && (
+                    )}
+                    {selectAccessor && (
                         <Icon
-                            id={`${
-                                item[selectAccessor]
-                                    ? 'selected'
-                                    : 'not-selected'
-                            }`}
+                            id={`${item[selectAccessor] ? 'selected' : 'not-selected'}`}
                             name='eye'
                             onClick={e => handleToggle(e, item)}
                         />
                     )}
                     <span className='story-group-menu-item'>{item[nameAccessor]}</span>
-                    {indexProp === index && saving && (
-                        <Loader active size='tiny' />
-                    )}
+                    {indexProp === index && saving && <Loader active size='tiny' />}
                 </>
             ) : (
                 <Input
@@ -127,13 +123,15 @@ function StoryGroupItem(props) {
                 className='warning'
                 header='Warning!'
                 confirmButton='Delete'
-                content={`The story group ${item[nameAccessor]} and all its stories in it will be deleted. This action cannot be undone.`}
+                content={`The story group ${
+                    item[nameAccessor]
+                } and all its stories in it will be deleted. This action cannot be undone.`}
                 onCancel={() => setDeletionModalVisible(false)}
                 onConfirm={removeStoryGroup}
             />
-        </Menu.Item>);
+        </Menu.Item>
+    );
 }
-
 
 StoryGroupItem.propTypes = {
     index: PropTypes.number.isRequired,

--- a/botfront/imports/ui/components/common/StoryGroupItem.jsx
+++ b/botfront/imports/ui/components/common/StoryGroupItem.jsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import {
+    Menu, Icon, Input, Loader, Confirm,
+} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import EllipsisMenu from './EllipsisMenu';
+
+
+function StoryGroupItem(props) {
+    const {
+        index,
+        item,
+        indexProp,
+        nameAccessor,
+        handleClickMenuItem,
+        selectAccessor,
+        allowEdit,
+        handleToggle,
+        saving,
+        stories,
+        changeName,
+    } = props;
+
+    const [deletionModalVisible, setDeletionModalVisible] = useState(false);
+    const [editing, setEditing] = useState(false);
+    const [storyName, setStoryName] = useState(item[nameAccessor]);
+
+    function resetNameEdit() {
+        setEditing(false);
+    }
+
+    function submitNameChange() {
+        changeName({ ...item, name: storyName });
+        resetNameEdit();
+    }
+
+    function handleKeyDownInput(event, element) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            event.stopPropagation();
+            submitNameChange(element);
+        }
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            event.stopPropagation();
+            resetNameEdit();
+        }
+    }
+
+    function handleNameChange(_, data) {
+        setStoryName(data.value);
+    }
+
+    
+    function removeStoryGroup() {
+        Meteor.call('storyGroups.delete', item);
+        setDeletionModalVisible(false);
+    }
+
+    return (
+        <Menu.Item
+            name={item[nameAccessor]}
+            className={indexProp === index ? 'selected-blue' : ''}
+            active={indexProp === index}
+            onClick={() => handleClickMenuItem(index)}
+            link={indexProp !== index}
+            data-cy='browser-item'
+        >
+            {!editing ? (
+            <>
+                {selectAccessor && (
+                    <Icon
+                        id={`${
+                            item[selectAccessor]
+                                ? 'selected'
+                                : 'not-selected'
+                        }`}
+                        name='eye'
+                        onClick={e => handleToggle(e, item)}
+                    />
+                )}
+                {allowEdit && (
+                    <EllipsisMenu
+                        handleEdit={() => setEditing(true)}
+                        handleDelete={() => setDeletionModalVisible(true)}
+                    />
+                )}
+                <span className='story-group-menu-item'>{item[nameAccessor]}</span>
+                {indexProp === index && saving && (
+                    <Loader active size='tiny' />
+                )}
+            </>
+            ) : (
+                <Input
+                    onChange={handleNameChange}
+                    value={storyName}
+                    onKeyDown={handleKeyDownInput}
+                    autoFocus
+                    onBlur={submitNameChange}
+                    fluid
+                    data-cy='edit-name'
+                />
+            )}
+            <Confirm
+                open={deletionModalVisible}
+                className='warning'
+                header='Warning!'
+                confirmButton='Delete'
+                content={`The story group ${item[nameAccessor]} and all its stories in it will be deleted. This action cannot be undone.`}
+                onCancel={() => setDeletionModalVisible(false)}
+                onConfirm={removeStoryGroup}
+            />
+        </Menu.Item>);
+}
+
+
+StoryGroupItem.propTypes = {
+    index: PropTypes.number.isRequired,
+    item: PropTypes.object.isRequired,
+    indexProp: PropTypes.number.isRequired,
+    nameAccessor: PropTypes.string,
+    handleClickMenuItem: PropTypes.func.isRequired,
+    selectAccessor: PropTypes.string,
+    allowEdit: PropTypes.bool,
+    handleToggle: PropTypes.func.isRequired,
+    saving: PropTypes.bool.isRequired,
+    stories: PropTypes.array.isRequired,
+    changeName: PropTypes.func.isRequired,
+};
+
+StoryGroupItem.defaultProps = {
+    nameAccessor: 'name',
+    selectAccessor: 'selected',
+    allowEdit: true,
+};
+
+export default StoryGroupItem;

--- a/botfront/imports/ui/components/common/StoryGroupItem.jsx
+++ b/botfront/imports/ui/components/common/StoryGroupItem.jsx
@@ -35,7 +35,7 @@ function StoryGroupItem(props) {
             .filter(story => story.checkpoints !== undefined);
         if (storiesWithCheckpoints !== []) {
             let originStories = storiesWithCheckpoints.map(story => story.checkpoints.map(checkpoint => checkpoint[0]));
-            originStories = originStories.flat(); // flatten the array, same as originStories.flat(), but flat is not supported by electron used by cypress
+            originStories = [].concat(...originStories); // flatten the array, same as originStories.flat(), but flat is not supported by electron used by cypress
             originStoriesInTheGroup = storiesIdsOfTheGroup.some(storyId => originStories.includes(storyId));
         }
         

--- a/botfront/imports/ui/components/common/style.import.less
+++ b/botfront/imports/ui/components/common/style.import.less
@@ -26,15 +26,17 @@
 }
 
 .ui.vertical.menu {
-    .item>#edit-icon {
-        opacity: 0.0;
-        &:hover{
-            opacity: .50;
-        }
+  .item:hover #ellipsis-icon {
+    color: #999999;
+    opacity: 1;
     }
 
-    .item:hover #edit-icon{
-        opacity: .40;
+  .item > #ellipsis-icon {
+    opacity: 0;
+    float: right;
+    &:hover {
+      color: #828282;
+    }
     }
 }
 .ui.vertical.menu{

--- a/botfront/imports/ui/components/common/style.import.less
+++ b/botfront/imports/ui/components/common/style.import.less
@@ -34,6 +34,7 @@
   .item > #ellipsis-icon {
     opacity: 0;
     float: right;
+    right: -8px;
     &:hover {
       color: #828282;
     }
@@ -43,7 +44,6 @@
     .item{
         .story-group-menu-item{
             height: 15px;
-            padding-right: 3em;
         }
     }
 }

--- a/botfront/imports/ui/components/common/style.import.less
+++ b/botfront/imports/ui/components/common/style.import.less
@@ -65,6 +65,6 @@
     color: #828282 !important; //important is used by semantic-ui, making the usage of important the only way to overide it
     background-color: #f2f2f2 !important; //important is used by semantic-ui, making the usage of important the only way to overide it
     &:hover {
-        background-color:#f2f2f2 !important; //important is used by semantic-ui, making the usage of important the only way to overide it
+        background-color:#f2f2f2; //important is used by semantic-ui, making the usage of important the only way to overide it
       } 
 }

--- a/botfront/imports/ui/components/common/style.import.less
+++ b/botfront/imports/ui/components/common/style.import.less
@@ -43,6 +43,7 @@
     .item{
         .story-group-menu-item{
             height: 15px;
+            padding-right: 3em;
         }
     }
 }
@@ -56,4 +57,14 @@
     &:hover {
         background-color:#c21616;
       }
+}
+
+
+.ui.menu .ui.dropdown .menu>.item#deleteDisabled{
+    cursor: not-allowed;
+    color: #828282 !important; //important is used by semantic-ui, making the usage of important the only way to overide it
+    background-color: #f2f2f2 !important; //important is used by semantic-ui, making the usage of important the only way to overide it
+    &:hover {
+        background-color:#f2f2f2 !important; //important is used by semantic-ui, making the usage of important the only way to overide it
+      } 
 }

--- a/botfront/imports/ui/components/common/style.import.less
+++ b/botfront/imports/ui/components/common/style.import.less
@@ -50,3 +50,10 @@
     padding: 13px 17px;
     text-align: left;
 }
+
+.warning .ui.primary.button {
+    background-color: #d02121;
+    &:hover {
+        background-color:#c21616;
+      }
+}


### PR DESCRIPTION
add an ellipsis menu 
story group deletion with a confirmation modal
cannot delete a story group with a linked or destination  story in it

- [x] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
