### PR TITLE
fix: crash on null intent_evaluation result

### DIFF
--- a/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
@@ -52,18 +52,18 @@ class Evaluation extends React.Component {
             evaluation: {
                 results: {
                     intent_evaluation: intentEvaluation,
-                    intent_evaluation: {
-                        report,
-                        predictions,
-                        accuracy,
-                        f1_score: f1Score,
-                        precision,
-                    } = {},
                 } = {},
             } = {},
         } = this.state;
 
         if (intentEvaluation) {
+            const {
+                report,
+                predictions,
+                accuracy,
+                f1_score: f1Score,
+                precision,
+            } = intentEvaluation;
             return [{
                 menuItem: 'Intents',
                 render: () => (


### PR DESCRIPTION
Fixes https://github.com/botfront/botfront/issues/244
