### PR TITLE
Fix/storygroups renaming

### DIFF
--- a/botfront/cypress/integration/stories/story_groups.spec.js
+++ b/botfront/cypress/integration/stories/story_groups.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 const storyGroupOne = 'storyGroupOne';
 const defaultStories = 'Default stories';
+const editedName = 'zstory';
 
 describe('stories', function() {
     afterEach(function() {
@@ -79,5 +80,31 @@ describe('stories', function() {
             .find('span')
             .contains(defaultStories)
             .should('exist');
+    });
+
+    it('after name edit, editing should display the right name', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('add-item').click({ force: true });
+        cy.dataCy('add-item-input')
+            .find('input')
+            .type(`${storyGroupOne}{enter}`);
+        cy.contains(defaultStories)
+            .find('[data-cy=ellipsis-menu]')
+            .click({ force: true })
+            .find('[data-cy=edit-menu]')
+            .click({ force: true });
+        cy.dataCy('edit-name')
+            .find('input')
+            .clear()
+            .type(`${editedName}{enter}`);
+
+        cy.contains(editedName)
+            .find('[data-cy=ellipsis-menu]')
+            .click({ force: true })
+            .find('[data-cy=edit-menu]')
+            .click({ force: true });
+        cy.dataCy('edit-name')
+            .find('input')
+            .should('have.value', editedName);
     });
 });

--- a/botfront/imports/ui/components/common/StoryGroupItem.jsx
+++ b/botfront/imports/ui/components/common/StoryGroupItem.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     Menu, Icon, Input, Loader, Confirm,
 } from 'semantic-ui-react';
@@ -24,6 +24,11 @@ function StoryGroupItem(props) {
     const [editing, setEditing] = useState(false);
     const [storyName, setStoryName] = useState(item[nameAccessor]);
     const [deletable, setDeletable] = useState(false);
+
+    useEffect(() => {
+        setStoryName(item[nameAccessor]);
+    }, [item]);
+
 
     function checkDeletable() {
         let originStoriesInTheGroup = false;


### PR DESCRIPTION
fix #260
useEffect was not used on to update the group name
so after a rename it was using the "old" one at its corresponding index

- [x] I wrote tests for the bug
- [ ] I documented the feature if needed

