### PR TITLE
fix: test destination story warning

### DIFF
--- a/botfront/cypress/integration/stories/story_exceptions.spec.js
+++ b/botfront/cypress/integration/stories/story_exceptions.spec.js
@@ -160,6 +160,7 @@ describe('story exceptions', function() {
         cy.dataCy('stories-linker')
             .first()
             .should('contains.text', 'excpetion test 2');
+        cy.get('.tiny').should('exist'); // check for the message signaling that it has been linked
         cy.dataCy('top-menu-warning-alert').should('not.exist');
     });
 });


### PR DESCRIPTION
add another check before looking for warnings, should fix cloud build issues
