### PR TITLE
Refactor/incoming tab

### DIFF
--- a/botfront/client/main.less
+++ b/botfront/client/main.less
@@ -20,6 +20,7 @@
 @import '../imports/ui/components/account/style.import.less';
 @import '../imports/ui/components/example_editor/style.import.less';
 @import '../imports/ui/components/settings/style.import.less';
+@import '../imports/ui/components/incoming/style.import.less';
 
 @sidebar-bg: rgb(45, 47, 74);
 @sidebar-size: 190px;

--- a/botfront/cypress/integration/incoming/new_utterances.spec.js
+++ b/botfront/cypress/integration/incoming/new_utterances.spec.js
@@ -1,0 +1,221 @@
+/* eslint-disable no-undef */
+
+describe('incoming page', function() {
+    beforeEach(function() {
+        cy.createProject('bf', 'My Project', 'en').then(() => {
+            cy.login();
+        });
+        cy.waitForResolve(Cypress.env('RASA_URL'));
+        cy.request('DELETE', `${Cypress.env('RASA_URL')}/model`);
+    });
+
+    afterEach(function() {
+        cy.logout();
+        cy.deleteProject('bf');
+    });
+
+    const addNewUtterances = () => {
+    // add utterances with populate
+        cy.visit('/project/bf/incoming');
+        cy.dataCy('incoming-populate-tab')
+            .click();
+        cy.get('textarea')
+            .click()
+            .type('test{enter}testing{enter}checking');
+        cy.get('button')
+            .contains('Add Utterances')
+            .click();
+        // define intents of new utterances
+        cy.dataCy('incoming-newutterances-tab')
+            .click();
+        cy.dataCy('null-nlu-table-intent')
+            .first()
+            .click();
+        cy.dataCy('intent-dropdown')
+            .trigger('mouseOver')
+            .click()
+            .find('input')
+            .trigger('mouseOver')
+            .type('test{enter}');
+        cy.dataCy('null-nlu-table-intent')
+            .first()
+            .click();
+        cy.dataCy('intent-dropdown')
+            .trigger('mouseOver')
+            .click()
+            .find('input')
+            .trigger('mouseOver')
+            .type('test2{enter}');
+        cy.dataCy('null-nlu-table-intent')
+            .first()
+            .click();
+        cy.dataCy('intent-dropdown')
+            .trigger('mouseOver')
+            .click()
+            .find('input')
+            .trigger('mouseOver')
+            .type('test{enter}');
+    };
+
+    it('should show available languages in the language selector', function() {
+        cy.visit('/project/bf/incoming');
+        // check project language exists
+        cy.dataCy('language-selector')
+            .click()
+            .find('span')
+            .contains('English')
+            .should('exist');
+        cy.dataCy('language-selector')
+            .click()
+            .find('span')
+            .contains('French')
+            .should('not.exist');
+        // add another language
+        cy.visit('/project/bf/settings');
+        cy.dataCy('language-selector')
+            .click({ force: true })
+            .find('.item')
+            .contains('French')
+            .click({ force: true });
+        cy.dataCy('save-changes')
+            .click({ force: true });
+        // check both languages are available
+        cy.visit('/project/bf/incoming');
+        cy.dataCy('language-selector')
+            .click()
+            .find('span')
+            .contains('English')
+            .should('exist');
+        cy.dataCy('language-selector')
+            .click()
+            .find('span')
+            .contains('French')
+            .should('exist');
+    });
+
+
+    it('should be able to link to evaluation from new utterances', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('train-button')
+            .click();
+        cy.wait(1000);
+        cy.get('[data-cy=train-button]').should('not.have.class', 'disabled');
+        // add utterances with populate
+        addNewUtterances();
+        // validate utterances and run evaluation
+        cy.dataCy('invalid-utterance-button')
+            .first()
+            .click();
+        cy.dataCy('invalid-utterance-button')
+            .first()
+            .click();
+        cy.dataCy('process-valid-utterances')
+            .click();
+        cy.dataCy('choose-action-dropdown')
+            .click()
+            .find('.item')
+            .contains('Run evaluation')
+            .click({ force: true });
+        cy.dataCy('confirm-action')
+            .click();
+        cy.get('.dimmer')
+            .find('button')
+            .contains('OK')
+            .click();
+        // check it linked to evalutaion > validated utterances
+        cy.contains('Use validated examples')
+            .should('exist');
+        cy.get('.active')
+            .contains('Use validated examples')
+            .should('exist');
+    });
+
+    it('should be able to add new utterances to nlu', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('train-button')
+            .click();
+        cy.wait(1000);
+        cy.get('[data-cy=train-button]').should('not.have.class', 'disabled');
+        // add utterances with populate
+        addNewUtterances();
+        cy.get('.rt-tbody')
+            .find('.rt-tr-group')
+            .first()
+            .find('span')
+            .contains('checking')
+            .should('exist');
+        // validate utterances and run evaluation
+        cy.dataCy('invalid-utterance-button')
+            .first()
+            .click();
+        cy.dataCy('invalid-utterance-button')
+            .first()
+            .click();
+        cy.dataCy('process-valid-utterances')
+            .click();
+        cy.dataCy('choose-action-dropdown')
+            .click()
+            .find('.item')
+            .contains('Add to training data')
+            .click({ force: true });
+        cy.dataCy('confirm-action')
+            .click();
+        cy.get('.dimmer')
+            .find('button')
+            .contains('OK')
+            .click();
+        cy.get('.rt-tbody')
+            .find('.rt-tr-group')
+            .first()
+            .find('span')
+            .contains('checking')
+            .should('not.exist');
+        // check utterances were added to nlu data
+        cy.get('.project-sidebar')
+            .find('.item')
+            .contains('NLU')
+            .click({ force: true });
+        cy.get('.rt-td')
+            .find('span')
+            .contains('checking')
+            .should('exist');
+        cy.get('.rt-td')
+            .find('span')
+            .contains('checking')
+            .should('exist');
+        cy.dataCy('nlu-table-intent')
+            .contains('test')
+            .should('exist');
+    });
+
+    it('should be able to invalidate utterances', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('train-button')
+            .click();
+        cy.wait(1000);
+        cy.get('[data-cy=train-button]').should('not.have.class', 'disabled');
+        // add utterances with populate
+        addNewUtterances();
+        cy.dataCy('invalid-utterance-button')
+            .first()
+            .click();
+        cy.dataCy('invalid-utterance-button')
+            .first()
+            .click();
+        cy.dataCy('process-valid-utterances')
+            .click();
+        cy.dataCy('choose-action-dropdown')
+            .click()
+            .find('.item')
+            .contains('Invalidate')
+            .click({ force: true });
+        cy.dataCy('confirm-action')
+            .click();
+        cy.get('.dimmer')
+            .find('button')
+            .contains('OK')
+            .click();
+        cy.dataCy('valid-utterance-button')
+            .should('not.exist');
+    });
+});

--- a/botfront/imports/api/activity.js
+++ b/botfront/imports/api/activity.js
@@ -72,7 +72,6 @@ Meteor.methods({
     'activity.getValidatedExamples'(modelId) {
         checkIfCan('nlu-admin', getProjectIdFromModelId(modelId));
         check(modelId, String);
-        console.log('data');
         try {
             const data = ActivityCollection.find({ modelId }).fetch() || [];
             return data;

--- a/botfront/imports/api/activity.js
+++ b/botfront/imports/api/activity.js
@@ -69,6 +69,18 @@ if (Meteor.isServer) {
 ActivityCollection.attachSchema(ActivitySchema);
 
 Meteor.methods({
+    'activity.getValidatedExamples'(modelId) {
+        checkIfCan('nlu-admin', getProjectIdFromModelId(modelId));
+        check(modelId, String);
+        console.log('data');
+        try {
+            const data = ActivityCollection.find({ modelId }).fetch() || [];
+            return data;
+        } catch (err) {
+            throw new Meteor.Error('500', err.message);
+        }
+    },
+
     'activity.deleteExamples'(modelId, itemIds) {
         checkIfCan('nlu-admin', getProjectIdFromModelId(modelId));
         check(itemIds, Array);

--- a/botfront/imports/api/nlu_model/nlu_model.utils.js
+++ b/botfront/imports/api/nlu_model/nlu_model.utils.js
@@ -61,7 +61,7 @@ export const getPublishedNluModelLanguages = (modelIds, asOptions = false) => {
     return languageCodes;
 };
 
-export const getPureIntents = (commonExamples) => {
+export const getPureIntents = (commonExamples = []) => {
     const pureIntents = new Set();
     commonExamples.forEach((e) => {
         if ((!e.entities || e.entities.length === 0) && e.intent) {

--- a/botfront/imports/startup/client/routes.jsx
+++ b/botfront/imports/startup/client/routes.jsx
@@ -7,7 +7,6 @@ import DocumentTitle from 'react-document-title';
 import { Meteor } from 'meteor/meteor';
 import { Provider } from 'react-redux';
 
-import ConversationsBrowser from '../../ui/components/conversations/ConversationsBrowser.jsx';
 import TemplatesContainer from '../../ui/components/templates/templates-list/Templates';
 import TemplateContainer from '../../ui/components/templates/template-upsert/Template';
 import SettingsContainer from '../../ui/components/admin/settings/Settings';
@@ -85,14 +84,6 @@ Meteor.startup(() => {
                         <Route path='/project/:project_id/nlu/legacy-models' component={NLUModels} name='NLU Models' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/nlu/models' component={NLUModelComponent} name='NLU Models' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/nlu/model/:model_id' component={NLUModelComponent} name='NLU Models' onEnter={authenticateProject} />
-                        <Route
-                            // path='/project/:project_id/dialogue/conversations(/p)(/:page)(/c)(/:conversation_id)'
-                            path='/fake/path'
-                            component={ConversationsBrowser}
-                            name='Conversations'
-                            onEnter={authenticateProject}
-                        />
-
                         <Route path='/project/:project_id/incoming' component={Incoming} name='Incoming' onEnter={authenticateProject} />
                         <Route
                             path='/project/:project_id/incoming/:model_id'

--- a/botfront/imports/startup/client/routes.jsx
+++ b/botfront/imports/startup/client/routes.jsx
@@ -20,6 +20,8 @@ import NLUModels from '../../ui/components/nlu/models/NLUModels';
 import SetupSteps from '../../ui/components/setup/SetupSteps';
 import Welcome from '../../ui/components/setup/Welcome';
 import Login from '../../ui/components/account/Login';
+import Incoming from '../../ui/components/incoming/Incoming';
+
 import { can, areScopeReady } from '../../lib/scopes';
 import AccountLayout from '../../ui/layouts/account';
 import NotFound from '../../ui/components/NotFound';
@@ -89,6 +91,7 @@ Meteor.startup(() => {
                             name='Conversations'
                             onEnter={authenticateProject}
                         />
+                        <Route path='/project/:project_id/incoming' component={Incoming} name='Incoming' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/stories' component={StoriesContainer} name='Stories' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/dialogue/templates' component={TemplatesContainer} name='Templates' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/dialogue/templates/add' component={TemplateContainer} name='Template' onEnter={authenticateProject} />

--- a/botfront/imports/startup/client/routes.jsx
+++ b/botfront/imports/startup/client/routes.jsx
@@ -91,7 +91,15 @@ Meteor.startup(() => {
                             name='Conversations'
                             onEnter={authenticateProject}
                         />
+                        <Route
+                            path='/project/:project_id/incoming/conversations(/:page)(/:conversation_id)'
+                            component={Incoming}
+                            name='Conversations'
+                            onEnter={authenticateProject}
+                        />
                         <Route path='/project/:project_id/incoming' component={Incoming} name='Incoming' onEnter={authenticateProject} />
+                        <Route path='/project/:project_id/incoming/model/:model_id' component={Incoming} name='Incoming' onEnter={authenticateProject} />
+                        
                         <Route path='/project/:project_id/stories' component={StoriesContainer} name='Stories' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/dialogue/templates' component={TemplatesContainer} name='Templates' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/dialogue/templates/add' component={TemplateContainer} name='Template' onEnter={authenticateProject} />

--- a/botfront/imports/startup/client/routes.jsx
+++ b/botfront/imports/startup/client/routes.jsx
@@ -86,19 +86,38 @@ Meteor.startup(() => {
                         <Route path='/project/:project_id/nlu/models' component={NLUModelComponent} name='NLU Models' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/nlu/model/:model_id' component={NLUModelComponent} name='NLU Models' onEnter={authenticateProject} />
                         <Route
-                            path='/project/:project_id/dialogue/conversations(/p)(/:page)(/c)(/:conversation_id)'
+                            // path='/project/:project_id/dialogue/conversations(/p)(/:page)(/c)(/:conversation_id)'
+                            path='/fake/path'
                             component={ConversationsBrowser}
                             name='Conversations'
                             onEnter={authenticateProject}
                         />
+
+                        <Route path='/project/:project_id/incoming' component={Incoming} name='Incoming' onEnter={authenticateProject} />
                         <Route
-                            path='/project/:project_id/incoming/conversations(/:page)(/:conversation_id)'
+                            path='/project/:project_id/incoming/:model_id'
                             component={Incoming}
-                            name='Conversations'
+                            name='Incoming'
                             onEnter={authenticateProject}
                         />
-                        <Route path='/project/:project_id/incoming' component={Incoming} name='Incoming' onEnter={authenticateProject} />
-                        <Route path='/project/:project_id/incoming/model/:model_id' component={Incoming} name='Incoming' onEnter={authenticateProject} />
+                        <Route
+                            path='/project/:project_id/incoming/:model_id/:tab'
+                            component={Incoming}
+                            name='Incoming'
+                            onEnter={authenticateProject}
+                        />
+                        <Route
+                            path='/project/:project_id/incoming/:model_id/:tab/:page'
+                            component={Incoming}
+                            name='Incoming'
+                            onEnter={authenticateProject}
+                        />
+                        <Route
+                            path='/project/:project_id/incoming/:model_id/:tab/:page/:selected_id'
+                            component={Incoming}
+                            name='Incoming'
+                            onEnter={authenticateProject}
+                        />
                         
                         <Route path='/project/:project_id/stories' component={StoriesContainer} name='Stories' onEnter={authenticateProject} />
                         <Route path='/project/:project_id/dialogue/templates' component={TemplatesContainer} name='Templates' onEnter={authenticateProject} />

--- a/botfront/imports/ui/components/common/LanguageDropdown.jsx
+++ b/botfront/imports/ui/components/common/LanguageDropdown.jsx
@@ -7,7 +7,6 @@ const LanguageDropdown = ({
     selectedLanguage,
     handleLanguageChange,
 }) => {
-    console.log(languageOptions);
     return (
         <Dropdown
             placeholder='Select Langugage'

--- a/botfront/imports/ui/components/common/LanguageDropdown.jsx
+++ b/botfront/imports/ui/components/common/LanguageDropdown.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown } from 'semantic-ui-react';
+
+const LanguageDropdown = ({
+    languageOptions,
+    selectedLanguage,
+    handleLanguageChange,
+}) => {
+    console.log(languageOptions);
+    return (
+        <Dropdown
+            placeholder='Select Langugage'
+            search
+            selection
+            value={selectedLanguage}
+            options={languageOptions}
+            onChange={(e, lang) => { handleLanguageChange(lang.value); }}
+            data-cy='model-selector'
+        />
+    );
+};
+
+LanguageDropdown.propTypes = {
+    languageOptions: PropTypes.array.isRequired,
+    selectedLanguage: PropTypes.string.isRequired,
+    handleLanguageChange: PropTypes.func.isRequired,
+};
+
+export default LanguageDropdown;

--- a/botfront/imports/ui/components/common/LanguageDropdown.jsx
+++ b/botfront/imports/ui/components/common/LanguageDropdown.jsx
@@ -6,19 +6,18 @@ const LanguageDropdown = ({
     languageOptions,
     selectedLanguage,
     handleLanguageChange,
-}) => {
-    return (
-        <Dropdown
-            placeholder='Select Langugage'
-            search
-            selection
-            value={selectedLanguage}
-            options={languageOptions}
-            onChange={(e, lang) => { handleLanguageChange(lang.value); }}
-            data-cy='model-selector'
-        />
-    );
-};
+}) => (
+    <Dropdown
+        className='language-dropdown'
+        placeholder='Select Langugage'
+        search
+        selection
+        value={selectedLanguage}
+        options={languageOptions}
+        onChange={(e, lang) => { handleLanguageChange(lang.value); }}
+        data-cy='model-selector'
+    />
+);
 
 LanguageDropdown.propTypes = {
     languageOptions: PropTypes.array.isRequired,

--- a/botfront/imports/ui/components/common/LanguageDropdown.jsx
+++ b/botfront/imports/ui/components/common/LanguageDropdown.jsx
@@ -15,7 +15,7 @@ const LanguageDropdown = ({
         value={selectedLanguage}
         options={languageOptions}
         onChange={(e, lang) => { handleLanguageChange(lang.value); }}
-        data-cy='model-selector'
+        data-cy='language-selector'
     />
 );
 

--- a/botfront/imports/ui/components/conversations/ConversationsBrowser.jsx
+++ b/botfront/imports/ui/components/conversations/ConversationsBrowser.jsx
@@ -29,14 +29,18 @@ class ConversationsBrowser extends React.Component {
     };
 
     goToNextPage = () => {
-        const { projectId, page, nextConvoId } = this.props;
-        browserHistory.push({ pathname: `/project/${projectId}/dialogue/conversations/p/${page + 1}/c/${nextConvoId}` });
+        const {
+            projectId, page, nextConvoId, modelId,
+        } = this.props;
+        browserHistory.push({ pathname: `/project/${projectId}/incoming/${modelId}/conversations/${page + 1}/${nextConvoId}` });
     };
 
     goToPreviousPage = () => {
-        const { projectId, page, prevConvoId } = this.props;
+        const {
+            projectId, page, prevConvoId, modelId,
+        } = this.props;
         if (page > 1) {
-            browserHistory.push({ pathname: `/project/${projectId}/dialogue/conversations/p/${page - 1}` });
+            browserHistory.push({ pathname: `/project/${projectId}/incoming/${modelId}/conversations/${page - 1}/${prevConvoId}` });
         }
     };
 
@@ -119,9 +123,9 @@ class ConversationsBrowser extends React.Component {
     }
 
     goToConversation(page, conversationId, replace = false) {
-        const { projectId } = this.props;
-        let url = `/project/${projectId}/dialogue/conversations/p/${page}`;
-        if (conversationId) url += `/c/${conversationId}`;
+        const { projectId, modelId } = this.props;
+        let url = `/project/${projectId}/incoming/${modelId}/conversations/${page || 1}`;
+        if (conversationId) url += `/${conversationId}`;
         if (replace) return browserHistory.replace({ pathname: url });
         return browserHistory.push({ pathname: url });
     }
@@ -138,7 +142,6 @@ class ConversationsBrowser extends React.Component {
 
     render() {
         const { trackers, activeConversationId } = this.props;
-
         return (
             <div>
                 {trackers.length > 0 ? (
@@ -170,16 +173,18 @@ ConversationsBrowser.propTypes = {
     projectId: PropTypes.string.isRequired,
     prevConvoId: PropTypes.string,
     nextConvoId: PropTypes.string,
+    modelId: PropTypes.string,
 };
 
 ConversationsBrowser.defaultProps = {
-    prevConvoId: null,
-    nextConvoId: null,
-    activeConversationId: null,
+    prevConvoId: {},
+    nextConvoId: {},
+    activeConversationId: {},
+    modelId: '',
 };
 
 function ConversationBrowserSegment({
-    loading, projectId, trackers, page, activeConversationId, prevConvoId, nextConvoId,
+    loading, projectId, trackers, page, activeConversationId, prevConvoId, nextConvoId, modelId,
 }) {
     return (
         <div>
@@ -194,6 +199,7 @@ function ConversationBrowserSegment({
                             page={page}
                             prevConvoId={prevConvoId}
                             nextConvoId={nextConvoId}
+                            modelId={modelId}
                         />
                     </Segment>
                 </Container>
@@ -210,6 +216,7 @@ ConversationBrowserSegment.propTypes = {
     page: PropTypes.number.isRequired,
     prevConvoId: PropTypes.string,
     nextConvoId: PropTypes.string,
+    modelId: PropTypes.string,
 };
 
 ConversationBrowserSegment.defaultProps = {
@@ -217,15 +224,20 @@ ConversationBrowserSegment.defaultProps = {
     activeConversationId: null,
     prevConvoId: null,
     nextConvoId: null,
+    modelId: '',
 };
 
 const ConversationsBrowserContainer = withTracker((props) => {
-    const projectId = props.router.params.project_id;
-    let activeConversationId = props.router.params.conversation_id;
-    let page = parseInt(props.router.params.page, 10);
+    // console.log(props.params);
+    const projectId = props.params.project_id;
+    let activeConversationId = props.params.selected_id;
+    // const { projectId } = props;
+    // let activeConversationId = '';
+    let page = parseInt(props.params.page, 10) || 1;
     if (!Number.isInteger(page) || page < 1) {
         page = 1;
     }
+    // let page = 1;
 
     // We take the previous element as well to have the id of the previous convo in the pagination
     const skip = Math.max(0, (page - 1) * PAGE_SIZE - 1);
@@ -237,7 +249,9 @@ const ConversationsBrowserContainer = withTracker((props) => {
         status: { $in: ['new', 'read', 'flagged'] },
     };
 
-    const componentProps = { page, projectId, loading: true };
+    const componentProps = {
+        page, projectId, loading: true, modelId: props.params.model_id,
+    };
     const conversationsHandler = Meteor.subscribe('conversations', projectId, skip, limit);
     
     if (conversationsHandler.ready()) {
@@ -273,12 +287,12 @@ const ConversationsBrowserContainer = withTracker((props) => {
             * conversations length could be over pagesize so we just wait front the next Tracker update with the right data */
             return componentProps;
         }
-        
         if (!activeConversationId) {
-            let url = `/project/${projectId}/dialogue/conversations/p/${page}`;
-            if (conversations.length > 0) url += `/c/${conversations[from]._id}`;
-            props.router.replace({ pathname: url });
+            let url = `/project/${projectId}/incoming/${props.params.model_id}/conversations/${page || 1}`;
+            if (conversations.length > 0) url += `/${conversations[from]._id}`;
+            props.replaceUrl({ pathname: url });
             return componentProps;
+            // activeConversationId = conversations[from]._id;
         }
 
         Object.assign(componentProps, {
@@ -296,6 +310,7 @@ const ConversationsBrowserContainer = withTracker((props) => {
         loading: true,
         projectId,
         page,
+        modelId: props.params.model_id,
     };
 })(ConversationBrowserSegment);
 

--- a/botfront/imports/ui/components/conversations/ConversationsBrowser.jsx
+++ b/botfront/imports/ui/components/conversations/ConversationsBrowser.jsx
@@ -11,7 +11,7 @@ import 'react-select/dist/react-select.css';
 
 import ConversationViewer from './ConversationViewer';
 import { Conversations } from '../../../api/conversations';
-import { Loading, PageMenu } from '../utils/Utils';
+import { Loading } from '../utils/Utils';
 import { wrapMeteorCallback } from '../utils/Errors';
 
 const PAGE_SIZE = 20;
@@ -188,9 +188,9 @@ function ConversationBrowserSegment({
 }) {
     return (
         <div>
-            <PageMenu title='Conversations History' icon='comments' />
             <Loading loading={loading}>
                 <Container>
+                    <Message info>Conversations for all languages are displayed.</Message>
                     <Segment>
                         <ConversationsBrowser
                             projectId={projectId}

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -24,8 +24,9 @@ class Incoming extends React.Component {
         this.state = { selectedModel: model || {} };
     }
 
-    linkRender = () => {
-        console.log('link rendered');
+    linkToEvaluation = () => {
+        const { router, projectId, model } = this.props;
+        router.push({ pathname: `/project/${projectId}/nlu/model/${model._id}`, state: { isActivityLinkRender: true } });
     };
 
     handleLanguageChange = (value) => {
@@ -76,7 +77,7 @@ class Incoming extends React.Component {
                             modelId={modelId}
                             entities={entities}
                             intents={intents}
-                            linkRender={this.linkRender}
+                            linkRender={this.linkToEvaluation}
                             instance={instance}
                             params={params}
                             replaceUrl={router.replace}

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -4,7 +4,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Menu, Container, Tab } from 'semantic-ui-react';
+import { Menu, Container } from 'semantic-ui-react';
 import { browserHistory } from 'react-router';
 import { uniq, sortBy } from 'lodash';
 
@@ -36,16 +36,6 @@ class Incoming extends React.Component {
         if (modelMatch) {
             this.setState({ selectedModel: modelMatch }, browserHistory.push({ pathname: `/project/${projectId}/incoming/${modelMatch._id}` }));
         }
-    }
-
-    renderPanes = () => {
-        const panes = [
-            { menuItem: 'New Utterances', render: () => <Tab.Pane>Incoming data</Tab.Pane> },
-            { menuItem: 'Conversations', render: () => <Tab.Pane>Conversations</Tab.Pane> },
-            { menuItem: 'Out of Scope', render: () => <Tab.Pane>Out of Scope data</Tab.Pane> },
-            { menuItem: 'Populate', render: () => <Tab.Pane>Populate data</Tab.Pane> },
-        ];
-        return panes;
     }
 
     render () {

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Incoming = () => {
+    return <div>Incoming</div>;
+};
+
+export default Incoming;

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -39,7 +39,7 @@ class Incoming extends React.Component {
 
     renderPanes = () => {
         const panes = [
-            { menuItem: 'Incoming', render: () => <Tab.Pane>Incoming data</Tab.Pane> },
+            { menuItem: 'New Utterances', render: () => <Tab.Pane>Incoming data</Tab.Pane> },
             { menuItem: 'Conversations', render: () => <Tab.Pane>Conversations</Tab.Pane> },
             { menuItem: 'Out of Scope', render: () => <Tab.Pane>Out of Scope data</Tab.Pane> },
             { menuItem: 'Populate', render: () => <Tab.Pane>Populate data</Tab.Pane> },

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -6,15 +6,19 @@ import PropTypes from 'prop-types';
 import { Menu, Container, Tab } from 'semantic-ui-react';
 
 import { Projects } from '../../../api/project/project.collection';
-import { getNluModelLanguages } from '../../../api/nlu_model/nlu_model.utils';
+import { NLUModels } from '../../../api/nlu_model/nlu_model.collection';
+import { getPublishedNluModelLanguages, getNluModelLanguages } from '../../../api/nlu_model/nlu_model.utils';
+import { Instances } from '../../../api/instances/instances.collection';
+
 import ConversationsBrowser from '../conversations/ConversationsBrowser.jsx';
+import Activity from '../nlu/activity/Activity';
 
 import LanguageDropdown from '../common/LanguageDropdown';
 
 class Incoming extends React.Component {
     constructor (props) {
         super(props);
-        this.state = { selectedLanguage: 'en', activeMenuItem: 'Incoming' };
+        this.state = { selectedLanguage: 'en' };
     }
 
     handleLanguageChange = (value) => {
@@ -26,7 +30,7 @@ class Incoming extends React.Component {
     renderPanes = () => {
         const panes = [
             { menuItem: 'Incoming', render: () => <Tab.Pane>Incoming data</Tab.Pane> },
-            { menuItem: 'Conversations', render: () => <Tab.Pane as={() => <ConversationsBrowser />} /> },
+            { menuItem: 'Conversations', render: () => <Tab.Pane>Conversations</Tab.Pane> },
             { menuItem: 'Out of Scope', render: () => <Tab.Pane>Out of Scope data</Tab.Pane> },
             { menuItem: 'Populate', render: () => <Tab.Pane>Populate data</Tab.Pane> },
         ];
@@ -34,8 +38,10 @@ class Incoming extends React.Component {
     }
 
     render () {
-        const { projectLanguages, ready } = this.props;
+        const { projectLanguages, ready, instances } = this.props;
         const { selectedLanguage } = this.state;
+        console.log(instances);
+
         if (!ready) {
             return <div>loading</div>;
         }
@@ -50,12 +56,14 @@ class Incoming extends React.Component {
                         />
                     </Menu.Item>
                 </Menu>
-                <Container>
-                    <Tab
-                        panes={this.renderPanes()}
-                        menu={{ secondary: true, pointing: true }}
-                    />
-                </Container>
+                <>
+                    <Container>
+                        <Tab
+                            panes={this.renderPanes()}
+                            menu={{ secondary: true, pointing: true }}
+                        />
+                    </Container>
+                </>
             </>
         );
     }
@@ -65,6 +73,13 @@ Incoming.propTypes = {
     projectLanguages: PropTypes.array,
     // projectId: PropTypes.string,
     ready: PropTypes.bool,
+    model: PropTypes.object.isRequired,
+    utterances: PropTypes.array.isRequired,
+    entities: PropTypes.array.isRequired,
+    intents: PropTypes.array.isRequired,
+    instances: PropTypes.object.isRequired,
+    linkRender: PropTypes.func.isRequired,
+    outDatedUtteranceIds: PropTypes.array.isRequired,
 };
 
 Incoming.defaultProps = {
@@ -76,9 +91,16 @@ Incoming.defaultProps = {
 const IncomingContainer = withTracker(({ projectId }) => {
     const project = Projects.findOne({ _id: projectId });
     const projectLanguages = getNluModelLanguages(project.nlu_models, true);
+    const instances = Instances.find({ projectId }).fetch();
+    const instance = instances ? instances.find(({ _id }) => _id === project.instance) : {};
+
+    console.log(instance);
     return {
         projectLanguages,
-        ready: !!projectLanguages,
+        ready: !!projectLanguages && !!instances,
+        project,
+        instances,
+        instance,
     };
 })(Incoming);
 

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -1,9 +1,12 @@
+/* eslint-disable camelcase */
 import React from 'react';
 import { withTracker } from 'meteor/react-meteor-data';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { Menu, Container, Tab } from 'semantic-ui-react';
+import { browserHistory, Link } from 'react-router';
+import { uniq, sortBy, find } from 'lodash';
 
 import { Projects } from '../../../api/project/project.collection';
 import { NLUModels } from '../../../api/nlu_model/nlu_model.collection';
@@ -18,11 +21,23 @@ import LanguageDropdown from '../common/LanguageDropdown';
 class Incoming extends React.Component {
     constructor (props) {
         super(props);
-        this.state = { selectedLanguage: 'en' };
+        const { model } = props;
+        this.state = { selectedModel: model || {} };
     }
 
+    linkRender = () => {
+        console.log('link rendered');
+    };
+
     handleLanguageChange = (value) => {
-        this.setState({ selectedLanguage: value });
+        const { models, projectId } = this.props;
+        const { selectedModel } = this.state;
+
+        const modelMatch = models.find(({ language }) => language === value);
+        console.log(modelMatch);
+        if (modelMatch) {
+            this.setState({ selectedModel: modelMatch }, browserHistory.push({ pathname: `/project/${projectId}/incoming/model/${modelMatch._id}` }));
+        }
     }
 
     // renderConversationBrowser = () => {}
@@ -38,48 +53,72 @@ class Incoming extends React.Component {
     }
 
     render () {
-        const { projectLanguages, ready, instances } = this.props;
-        const { selectedLanguage } = this.state;
-        console.log(instances);
+        const { projectLanguages, ready, instance, entities, intents, modelId, project, model } = this.props;
+        const { selectedModel } = this.state;
 
-        if (!ready) {
+        if (!ready || !model) {
             return <div>loading</div>;
         }
+        console.log(model);
         return (
             <>
                 <Menu pointing secondary className='top-menu'>
                     <Menu.Item header className='top-menu-item'>
                         <LanguageDropdown
                             languageOptions={projectLanguages}
-                            selectedLanguage={selectedLanguage}
+                            selectedLanguage={selectedModel.language}
                             handleLanguageChange={this.handleLanguageChange}
                         />
                     </Menu.Item>
                 </Menu>
                 <>
                     <Container>
-                        <Tab
-                            panes={this.renderPanes()}
-                            menu={{ secondary: true, pointing: true }}
-                        />
+                        <Activity project={project} modelId={modelId} entities={entities} intents={intents} linkRender={this.linkRender} instance={instance} />
                     </Container>
+                    
                 </>
             </>
         );
+        // return (
+        //     <>
+        //         <Menu pointing secondary className='top-menu'>
+        //             <Menu.Item header className='top-menu-item'>
+        //                 <LanguageDropdown
+        //                     languageOptions={projectLanguages}
+        //                     selectedLanguage={selectedModel.language}
+        //                     handleLanguageChange={this.handleLanguageChange}
+        //                 />
+        //             </Menu.Item>
+        //         </Menu>
+        //         <>
+        //             <Container>
+        //                 <Tab
+        //                     panes={this.renderPanes()}
+        //                     menu={{ secondary: true, pointing: true }}
+        //                 />
+        //             </Container>
+        //             <Activity project={project} modelId={modelId} entities={entities} intents={intents} linkRender={this.linkRender} instance={instance} />
+        //         </>
+        //     </>
+        // );
     }
 }
 
 Incoming.propTypes = {
     projectLanguages: PropTypes.array,
-    // projectId: PropTypes.string,
+    projectId: PropTypes.string,
+    project: PropTypes.object.isRequired,
     ready: PropTypes.bool,
     model: PropTypes.object.isRequired,
+    models: PropTypes.array.isRequired,
     utterances: PropTypes.array.isRequired,
     entities: PropTypes.array.isRequired,
     intents: PropTypes.array.isRequired,
-    instances: PropTypes.object.isRequired,
+    instances: PropTypes.array.isRequired,
+    instance: PropTypes.object.isRequired,
     linkRender: PropTypes.func.isRequired,
     outDatedUtteranceIds: PropTypes.array.isRequired,
+    modelId: PropTypes.string.isRequired,
 };
 
 Incoming.defaultProps = {
@@ -88,19 +127,73 @@ Incoming.defaultProps = {
     ready: false,
 };
 
-const IncomingContainer = withTracker(({ projectId }) => {
-    const project = Projects.findOne({ _id: projectId });
+const handleDefaultRoute = (projectId) => {
+    const { nlu_models: modelIds = [], defaultLanguage } = Projects.findOne({ _id: projectId }, { fields: { nlu_models: 1, defaultLanguage: 1 } }) || {};
+    const models = NLUModels.find({ _id: { $in: modelIds } }, { sort: { language: 1 } }).fetch();
+
+    try {
+        const defaultModelId = models.find(model => model.language === defaultLanguage)._id;
+        browserHistory.push({ pathname: `/project/${projectId}/incoming/model/${defaultModelId}` });
+    } catch (e) {
+        browserHistory.push({ pathname: `/project/${projectId}/incoming/model/${modelIds[0]}` });
+    }
+};
+
+const IncomingContainer = withTracker((props) => {
+    const { params: { model_id: modelId, project_id: projectId } = {} } = props;
+
+    let modelHandler = {
+        ready() {
+            return false;
+        },
+    };
+    if (modelId) {
+        modelHandler = Meteor.subscribe('nlu_models', modelId);
+    }
+    
+    const instancesHandler = Meteor.subscribe('nlu_instances', projectId);
+    const project = Projects.findOne({ _id: projectId }) || {};
     const projectLanguages = getNluModelLanguages(project.nlu_models, true);
     const instances = Instances.find({ projectId }).fetch();
     const instance = instances ? instances.find(({ _id }) => _id === project.instance) : {};
 
-    console.log(instance);
+    const model = NLUModels.findOne({ _id: modelId });
+    const models = NLUModels.find({ _id: { $in: project.nlu_models }, published: true }, { sort: { language: 1 } }, { fields: { language: 1, _id: 1 } }).fetch();
+
+    if (!modelId || !project.nlu_models.includes(modelId)) {
+        handleDefaultRoute(projectId);
+    }
+
+    if (!model) {
+        console.log('no model');
+        return {};
+    }
+    const { training_data: { common_examples = [] } = {} } = model;
+
+    const intents = sortBy(uniq(common_examples.map(e => e.intent)));
+    const entities = [];
+    common_examples.forEach((e) => {
+        if (e.entities) {
+            e.entities.forEach((ent) => {
+                if (entities.indexOf(ent.entity) === -1) {
+                    entities.push(ent.entity);
+                }
+            });
+        }
+    });
+
+
     return {
         projectLanguages,
-        ready: !!projectLanguages && !!instances,
+        ready: !!projectLanguages && !!instances && instancesHandler.ready() && modelHandler.ready(),
         project,
         instances,
         instance,
+        modelId,
+        model,
+        models,
+        intents,
+        entities,
     };
 })(Incoming);
 

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -61,8 +61,8 @@ class Incoming extends React.Component {
         }
         return (
             <>
-                <Menu pointing secondary className='top-menu'>
-                    <Menu.Item header className='top-menu-item'>
+                <Menu borderless className='top-menu'>
+                    <Menu.Item header>
                         <LanguageDropdown
                             languageOptions={projectLanguages}
                             selectedLanguage={selectedModel.language}

--- a/botfront/imports/ui/components/incoming/Incoming.jsx
+++ b/botfront/imports/ui/components/incoming/Incoming.jsx
@@ -1,7 +1,89 @@
 import React from 'react';
+import { withTracker } from 'meteor/react-meteor-data';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
-const Incoming = () => {
-    return <div>Incoming</div>;
+import { Menu, Container, Tab } from 'semantic-ui-react';
+
+import { Projects } from '../../../api/project/project.collection';
+import { getNluModelLanguages } from '../../../api/nlu_model/nlu_model.utils';
+import ConversationsBrowser from '../conversations/ConversationsBrowser.jsx';
+
+import LanguageDropdown from '../common/LanguageDropdown';
+
+class Incoming extends React.Component {
+    constructor (props) {
+        super(props);
+        this.state = { selectedLanguage: 'en', activeMenuItem: 'Incoming' };
+    }
+
+    handleLanguageChange = (value) => {
+        this.setState({ selectedLanguage: value });
+    }
+
+    // renderConversationBrowser = () => {}
+
+    renderPanes = () => {
+        const panes = [
+            { menuItem: 'Incoming', render: () => <Tab.Pane>Incoming data</Tab.Pane> },
+            { menuItem: 'Conversations', render: () => <Tab.Pane as={() => <ConversationsBrowser />} /> },
+            { menuItem: 'Out of Scope', render: () => <Tab.Pane>Out of Scope data</Tab.Pane> },
+            { menuItem: 'Populate', render: () => <Tab.Pane>Populate data</Tab.Pane> },
+        ];
+        return panes;
+    }
+
+    render () {
+        const { projectLanguages, ready } = this.props;
+        const { selectedLanguage } = this.state;
+        if (!ready) {
+            return <div>loading</div>;
+        }
+        return (
+            <>
+                <Menu pointing secondary className='top-menu'>
+                    <Menu.Item header className='top-menu-item'>
+                        <LanguageDropdown
+                            languageOptions={projectLanguages}
+                            selectedLanguage={selectedLanguage}
+                            handleLanguageChange={this.handleLanguageChange}
+                        />
+                    </Menu.Item>
+                </Menu>
+                <Container>
+                    <Tab
+                        panes={this.renderPanes()}
+                        menu={{ secondary: true, pointing: true }}
+                    />
+                </Container>
+            </>
+        );
+    }
+}
+
+Incoming.propTypes = {
+    projectLanguages: PropTypes.array,
+    // projectId: PropTypes.string,
+    ready: PropTypes.bool,
 };
 
-export default Incoming;
+Incoming.defaultProps = {
+    projectLanguages: [],
+    // projectId: '',
+    ready: false,
+};
+
+const IncomingContainer = withTracker(({ projectId }) => {
+    const project = Projects.findOne({ _id: projectId });
+    const projectLanguages = getNluModelLanguages(project.nlu_models, true);
+    return {
+        projectLanguages,
+        ready: !!projectLanguages,
+    };
+})(Incoming);
+
+const mapStateToProps = state => ({
+    projectId: state.settings.get('projectId'),
+});
+
+export default connect(mapStateToProps)(IncomingContainer);

--- a/botfront/imports/ui/components/incoming/TopMenu.jsx
+++ b/botfront/imports/ui/components/incoming/TopMenu.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Menu } from 'semantic-ui-react';
+
+
+import LanguageDropdown from '../common/LanguageDropdown';
+
+const TopMenu = ({ projectLanguages, selectedModel, handleLanguageChange }) => (
+    <Menu borderless className='top-menu'>
+        <Menu.Item header>
+            <LanguageDropdown
+                languageOptions={projectLanguages}
+                selectedLanguage={selectedModel.language}
+                handleLanguageChange={handleLanguageChange}
+            />
+        </Menu.Item>
+    </Menu>
+);
+
+TopMenu.propTypes = {
+    projectLanguages: PropTypes.array.isRequired,
+    selectedModel: PropTypes.object.isRequired,
+    handleLanguageChange: PropTypes.func.isRequired,
+};
+
+export default TopMenu;

--- a/botfront/imports/ui/components/incoming/style.import.less
+++ b/botfront/imports/ui/components/incoming/style.import.less
@@ -1,6 +1,3 @@
-.ui.pointing.secondary.menu.top-menu {
+.ui.borderless.menu.top-menu {
     height: @top-menu-height;
-    .header.item.top-menu-item {
-        padding-bottom: 0.3rem;
-    }
 }

--- a/botfront/imports/ui/components/incoming/style.import.less
+++ b/botfront/imports/ui/components/incoming/style.import.less
@@ -1,0 +1,6 @@
+.ui.pointing.secondary.menu.top-menu {
+    height: @top-menu-height;
+    .header.item.top-menu-item {
+        padding-bottom: 0.3rem;
+    }
+}

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -65,7 +65,7 @@ class Activity extends React.Component {
             { menuItem: this.createMenuItem('New Utterances', 0), render: this.renderIncomingTab },
             {
                 menuItem: this.createMenuItem('Conversations', 1),
-                render: () => <ConversationBrowser projectId={project._id} params={params} modelId={model._id} replaceUrl={replaceUrl} />,
+                render: () => <ConversationBrowser projectId={project._id} params={params} replaceUrl={replaceUrl} />,
             },
             { menuItem: this.createMenuItem('Populate', 2), render: () => <ActivityInsertions model={model} instance={instance} /> },
         ];

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -53,12 +53,12 @@ class Activity extends React.Component {
             model, instance, project, params, replaceUrl,
         } = this.props;
         return [
-            { menuItem: this.createMenuItem('Incoming', 0), render: this.renderIncomingTab },
-            { menuItem: this.createMenuItem('Populate', 1), render: () => <ActivityInsertions model={model} instance={instance} /> },
+            { menuItem: this.createMenuItem('New Utterances', 0), render: this.renderIncomingTab },
             {
-                menuItem: this.createMenuItem('Conversations', 2),
+                menuItem: this.createMenuItem('Conversations', 1),
                 render: () => <Tab.Pane><ConversationBrowser projectId={project._id} params={params} modelId={model._id} replaceUrl={replaceUrl} /></Tab.Pane>,
             },
+            { menuItem: this.createMenuItem('Populate', 2), render: () => <ActivityInsertions model={model} instance={instance} /> },
         ];
     }
     
@@ -80,9 +80,6 @@ class Activity extends React.Component {
     onValidateExamples = utterances => this.onExamplesEdit(utterances.map(e => ({ ...e, validated: !e.validated })));
 
     onExamplesEdit = (utterances, callback) => {
-        console.log('in examples edit');
-        console.log(utterances);
-
         Meteor.call('activity.updateExamples', utterances, wrapMeteorCallback(callback));
     };
 

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -31,19 +31,22 @@ class Activity extends React.Component {
 
     state = this.getDefaultState();
 
+    componentDidMount = () => {
+        const { params } = this.props;
+        const { activeTabIndex } = this.state;
+        if (activeTabIndex === undefined && !params.tab) this.setState({ activeTabIndex: 0 });
+    }
+
     createMenuItem = (name, index) => {
         const {
             model, projectId, params, replaceUrl,
         } = this.props;
-        const { activeTabIndex } = this.state;
         const regexp = / /g;
         const urlId = name.toLowerCase().replace(regexp, '');
         const url = `/project/${projectId}/incoming/${model._id}/${urlId}`;
-        if (activeTabIndex === undefined && params.tab === urlId) {
-            this.setState({ activeTabIndex: index });
-        }
         return {
             name,
+            key: `incoming-tab-${index}`,
             'data-cy': `incoming-${urlId}-tab`,
             onClick: () => {
                 // const url = `/project/${projectId}/model/${model._id}/${urlId}`;
@@ -62,7 +65,7 @@ class Activity extends React.Component {
             { menuItem: this.createMenuItem('New Utterances', 0), render: this.renderIncomingTab },
             {
                 menuItem: this.createMenuItem('Conversations', 1),
-                render: () => <Tab.Pane><ConversationBrowser projectId={project._id} params={params} modelId={model._id} replaceUrl={replaceUrl} /></Tab.Pane>,
+                render: () => <ConversationBrowser projectId={project._id} params={params} modelId={model._id} replaceUrl={replaceUrl} />,
             },
             { menuItem: this.createMenuItem('Populate', 2), render: () => <ActivityInsertions model={model} instance={instance} /> },
         ];
@@ -114,8 +117,8 @@ class Activity extends React.Component {
         const filteredExamples = filterFn(utterances);
         return utterances && utterances.length > 0 ? (
             <>
-                <Segment.Group className='new-utterances-topbar' horizontal borderless>
-                    <Segment className='new-utterances-topbar-section' inline tertiary compact floated='left'>
+                <Segment.Group className='new-utterances-topbar' horizontal>
+                    <Segment className='new-utterances-topbar-section' tertiary compact floated='left'>
                         <ActivityActions
                             onEvaluate={this.onEvaluate}
                             onDelete={() => this.batchDelete(modelId, filteredExamples.map(e => e._id))}
@@ -145,7 +148,6 @@ class Activity extends React.Component {
                                 onChange={(e, option) => {
                                     this.setState({ sortType: option.value, isSortDropdownOpen: false });
                                 }}
-                                onMouseLeave
                             />
                         </Button.Group>
                     </Segment>
@@ -167,16 +169,9 @@ class Activity extends React.Component {
         );
     };
 
-    selectInitialTab = () => {
-        const { params } = this.props;
-        const { activeTabIndex } = this.state;
-        if (activeTabIndex === undefined && !params.tab) this.setState({ activeTabIndex: 0 });
-    }
-
     render() {
         const { ready } = this.props;
         const { activeTabIndex } = this.state;
-        this.selectInitialTab();
         return (
             <Loading loading={!ready}>
                 <Tab

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -44,7 +44,7 @@ class Activity extends React.Component {
         }
         return {
             name,
-            // active: params.tab === urlId,
+            'data-cy': `incoming-${urlId}-tab`,
             onClick: () => {
                 // const url = `/project/${projectId}/model/${model._id}/${urlId}`;
                 if (params.tab === urlId) return;
@@ -137,7 +137,7 @@ class Activity extends React.Component {
                                 className='button icon'
                                 value={sortType}
                                 trigger={(
-                                    <Segment className='button sort-dropdown-trigger'>
+                                    <Segment className='button sort-dropdown-trigger' data-cy='sort-utterances-dropdown'>
                                         Sort by: <b>{this.dropdownOptions.find(({ value }) => value === sortType).text}</b>
                                     </Segment>
                                 )}

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -6,7 +6,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { sortBy, uniq } from 'lodash';
 import moment from 'moment';
 import {
-    Tab, Message,
+    Tab, Message, Dropdown, Segment,
 } from 'semantic-ui-react';
 
 import { connect } from 'react-redux';
@@ -21,7 +21,7 @@ import { wrapMeteorCallback } from '../../utils/Errors';
 import ConversationBrowser from '../../conversations/ConversationsBrowser';
 
 class Activity extends React.Component {
-    getDefaultState = () => ({ filterFn: utterances => utterances, activeTabIndex: undefined }); // eslint-disable-line react/sort-comp
+    getDefaultState = () => ({ filterFn: utterances => utterances, activeTabIndex: undefined, sortType: 'mostRecent' }); // eslint-disable-line react/sort-comp
 
     state = this.getDefaultState();
 
@@ -94,22 +94,45 @@ class Activity extends React.Component {
             numValidated,
         } = this.props;
 
-        const { filterFn } = this.state;
+        const { filterFn, sortType } = this.state;
         const filteredExamples = filterFn(utterances);
-
         return utterances && utterances.length > 0 ? (
             <>
-                <ActivityActions
-                    onEvaluate={this.onEvaluate}
-                    onDelete={() => this.batchDelete(modelId, filteredExamples.map(e => e._id))}
-                    onAddToTraining={this.batchAdd}
-                    onDone={() => this.setState(this.getDefaultState())}
-                    onValidate={() => this.onValidateExamples(filteredExamples)}
-                    numValidated={numValidated}
-                    // eslint-disable-next-line no-shadow
-                    onFilterChange={filterFn => this.setState({ filterFn })}
-                    projectId={projectId}
-                />
+                <Segment.Group className='new-utterances-topbar' horizontal borderless>
+                    <Segment className='new-utterances-topbar-section' inline tertiary compact floated='left'>
+                        <ActivityActions
+                            onEvaluate={this.onEvaluate}
+                            onDelete={() => this.batchDelete(modelId, filteredExamples.map(e => e._id))}
+                            onAddToTraining={this.batchAdd}
+                            onDone={() => this.setState(this.getDefaultState())}
+                            onValidate={() => this.onValidateExamples(filteredExamples)}
+                            numValidated={numValidated}
+                            // eslint-disable-next-line no-shadow
+                            onFilterChange={filterFn => this.setState({ filterFn })}
+                            projectId={projectId}
+                        />
+                    </Segment>
+                    <Segment className='new-utterances-topbar-section' tertiary compact floated='right'>
+                        <Segment className='sort-utterances-wrapper' compact floated='right'>
+                            sort by:{' '}
+                            <Dropdown
+                                inline
+                                floating
+                                placeholder='Sort by:'
+                                value={sortType}
+                                options={[
+                                    { value: 'mostRecent', text: 'Date descending' },
+                                    { value: 'leastRecent', text: 'Date ascending' },
+                                ]}
+                                onChange={(e, option) => {
+                                    this.setState({ sortType: option.value });
+                                }}
+                            />
+                        </Segment>
+                        
+                    </Segment>
+                </Segment.Group>
+                
                 <br />
                 <ActivityDataTable
                     utterances={utterances}
@@ -118,6 +141,7 @@ class Activity extends React.Component {
                     projectId={projectId}
                     outDatedUtteranceIds={outDatedUtteranceIds}
                     modelId={modelId}
+                    sortBy={sortType}
                 />
             </>
         ) : (

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -18,6 +18,7 @@ import { ActivityCollection } from '../../../../api/activity';
 import { NLUModels } from '../../../../api/nlu_model/nlu_model.collection';
 import { getPureIntents } from '../../../../api/nlu_model/nlu_model.utils';
 import { wrapMeteorCallback } from '../../utils/Errors';
+import ConversationBrowser from '../../conversations/ConversationsBrowser';
 
 class Activity extends React.Component {
     getDefaultState = () => ({ filterFn: utterances => utterances }); // eslint-disable-line react/sort-comp
@@ -93,7 +94,12 @@ class Activity extends React.Component {
             <Loading loading={!ready}>
                 <Tab
                     menu={{ pointing: true, secondary: true }}
-                    panes={[{ menuItem: 'Incoming', render: this.renderIncomingTab }, { menuItem: 'Populate', render: () => <ActivityInsertions model={model} instance={instance} /> }]}
+                    panes={[
+                        { menuItem: 'Incoming', render: this.renderIncomingTab },
+                        { menuItem: 'Populate', render: () => <ActivityInsertions model={model} instance={instance} /> },
+                        { menuItem: 'Conversations', render: () => <Tab.Pane><ConversationBrowser /></Tab.Pane> },
+                        { menuItem: 'Out of Scope', render: () => <Tab.Pane>Out of Scope data</Tab.Pane> },
+                    ]}
                 />
             </Loading>
         );
@@ -150,7 +156,7 @@ const ActivityContainer = withTracker((props) => {
                 }),
         );
     }
-
+    console.log(entities);
     return {
         model,
         pureIntents,

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -6,7 +6,7 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { sortBy, uniq } from 'lodash';
 import moment from 'moment';
 import {
-    Tab, Message, Dropdown, Segment,
+    Tab, Message, Dropdown, Segment, Button,
 } from 'semantic-ui-react';
 
 import { connect } from 'react-redux';
@@ -21,7 +21,13 @@ import { wrapMeteorCallback } from '../../utils/Errors';
 import ConversationBrowser from '../../conversations/ConversationsBrowser';
 
 class Activity extends React.Component {
-    getDefaultState = () => ({ filterFn: utterances => utterances, activeTabIndex: undefined, sortType: 'mostRecent' }); // eslint-disable-line react/sort-comp
+    // eslint-disable-next-line react/sort-comp
+    getDefaultState = () => ({
+        filterFn: utterances => utterances,
+        activeTabIndex: undefined,
+        sortType: 'mostRecent',
+        isSortDropdownOpen: false,
+    });
 
     state = this.getDefaultState();
 
@@ -83,6 +89,16 @@ class Activity extends React.Component {
         Meteor.call('activity.updateExamples', utterances, wrapMeteorCallback(callback));
     };
 
+    dropdownOptions = [
+        { value: 'mostRecent', text: 'Newest' },
+        { value: 'leastRecent', text: 'Oldest' },
+    ];
+
+    toggleSortDropdown = () => {
+        const { isSortDropdownOpen } = this.state;
+        this.setState({ isSortDropdownOpen: !isSortDropdownOpen });
+    }
+
     renderIncomingTab = () => {
         const {
             model: { _id: modelId },
@@ -94,7 +110,7 @@ class Activity extends React.Component {
             numValidated,
         } = this.props;
 
-        const { filterFn, sortType } = this.state;
+        const { filterFn, sortType, isSortDropdownOpen } = this.state;
         const filteredExamples = filterFn(utterances);
         return utterances && utterances.length > 0 ? (
             <>
@@ -113,23 +129,25 @@ class Activity extends React.Component {
                         />
                     </Segment>
                     <Segment className='new-utterances-topbar-section' tertiary compact floated='right'>
-                        <Segment className='sort-utterances-wrapper' compact floated='right'>
-                            sort by:{' '}
+                        <Button.Group className='sort-dropdown' basic onClick={() => { this.setState({ isSortDropdownOpen: !isSortDropdownOpen }); }}>
                             <Dropdown
-                                inline
+                                onClick={() => { this.setState({ isSortDropdownOpen: !isSortDropdownOpen }); }}
+                                open={isSortDropdownOpen}
                                 floating
-                                placeholder='Sort by:'
+                                className='button icon'
                                 value={sortType}
-                                options={[
-                                    { value: 'mostRecent', text: 'Date descending' },
-                                    { value: 'leastRecent', text: 'Date ascending' },
-                                ]}
+                                trigger={(
+                                    <Segment className='button sort-dropdown-trigger'>
+                                        Sort by: <b>{this.dropdownOptions.find(({ value }) => value === sortType).text}</b>
+                                    </Segment>
+                                )}
+                                options={this.dropdownOptions}
                                 onChange={(e, option) => {
-                                    this.setState({ sortType: option.value });
+                                    this.setState({ sortType: option.value, isSortDropdownOpen: false });
                                 }}
+                                onMouseLeave
                             />
-                        </Segment>
-                        
+                        </Button.Group>
                     </Segment>
                 </Segment.Group>
                 

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -59,7 +59,6 @@ class Activity extends React.Component {
                 menuItem: this.createMenuItem('Conversations', 2),
                 render: () => <Tab.Pane><ConversationBrowser projectId={project._id} params={params} modelId={model._id} replaceUrl={replaceUrl} /></Tab.Pane>,
             },
-            { menuItem: this.createMenuItem('Out of Scope', 3), render: () => <Tab.Pane>Out of Scope data</Tab.Pane> },
         ];
     }
     
@@ -81,6 +80,9 @@ class Activity extends React.Component {
     onValidateExamples = utterances => this.onExamplesEdit(utterances.map(e => ({ ...e, validated: !e.validated })));
 
     onExamplesEdit = (utterances, callback) => {
+        console.log('in examples edit');
+        console.log(utterances);
+
         Meteor.call('activity.updateExamples', utterances, wrapMeteorCallback(callback));
     };
 

--- a/botfront/imports/ui/components/nlu/activity/ActivityActions.jsx
+++ b/botfront/imports/ui/components/nlu/activity/ActivityActions.jsx
@@ -114,13 +114,14 @@ export default class ActivityActions extends React.Component {
                     icon
                     labelPosition='left'
                     onClick={e => this.handleDataChanged(e, { value: 'VALIDATED' })}
+                    data-cy='process-valid-utterances'
                 >
                     <Icon name='angle double right' /> {`Process ${numValidated > 0 ? numValidated : ''} validated utterance${numValidated === 1 ? '' : 's'}`}
                 </Button>
                 &nbsp;
                 &nbsp;
                 {dataFilter && (
-                    <Button.Group size='small' color='yellow' basic style={noBorder}>
+                    <Button.Group size='small' color='yellow' basic style={noBorder} data-cy='choose-utterance-action'>
                         <Dropdown
                             button
                             className='icon'
@@ -131,6 +132,7 @@ export default class ActivityActions extends React.Component {
                             value={action}
                             options={actionOptions}
                             onChange={this.handleActionChanged}
+                            data-cy='choose-action-dropdown'
                         />
                     </Button.Group>
                 )
@@ -140,7 +142,15 @@ export default class ActivityActions extends React.Component {
                 &nbsp;
                 {dataFilter && (
                     <Button.Group size='small'>
-                        {action && <Button icon='check' content='confirm' color='green' onClick={() => this.setState({ confirmOpen: true })} />}
+                        {action && (
+                            <Button
+                                icon='check'
+                                content='confirm'
+                                color='green'
+                                onClick={() => this.setState({ confirmOpen: true })}
+                                data-cy='confirm-action'
+                            />
+                        )}
                         <Button icon='remove' basic content='Cancel' onClick={() => this.finish()} />
                     </Button.Group>
                 )

--- a/botfront/imports/ui/components/nlu/activity/ActivityDataTable.jsx
+++ b/botfront/imports/ui/components/nlu/activity/ActivityDataTable.jsx
@@ -52,14 +52,24 @@ export default class ActivityDataTable extends React.Component {
                         )
                         : <Button size={size} disabled basic icon='redo' loading />;
                 } else if (!!validated) {
-                    action = <Button size={size} onClick={() => this.onValidate(utterance)} color='green' icon='check' />;
+                    action = <Button size={size} onClick={() => this.onValidate(utterance)} color='green' icon='check' data-cy='valid-utterance-button' />;
                 } else {
                     action = (
                         <Popup
                             size='mini'
                             inverted
                             content='Mark this utterance valid'
-                            trigger={<Button basic size={size} disabled={ooS} onClick={() => this.onValidate(utterance)} color='green' icon='check' />}
+                            trigger={(
+                                <Button
+                                    basic
+                                    size={size}
+                                    disabled={ooS}
+                                    onClick={() => this.onValidate(utterance)}
+                                    color='green'
+                                    icon='check'
+                                    data-cy='invalid-utterance-button'
+                                />
+                            )}
                         />
                     );
                 }

--- a/botfront/imports/ui/components/nlu/activity/ActivityDataTable.jsx
+++ b/botfront/imports/ui/components/nlu/activity/ActivityDataTable.jsx
@@ -233,14 +233,30 @@ export default class ActivityDataTable extends React.Component {
         </Button>
     );
 
+    sortUtterances = () => {
+        const { sortBy } = this.props;
+        const { utterances } = this.props;
+        if (sortBy === 'mostRecent') {
+            return utterances.sort(({ createdAt: dateA }, { createdAt: dateB }) => (
+                new Date(dateB) - new Date(dateA)
+            ));
+        }
+        if (sortBy === 'leastRecent') {
+            return utterances.sort(({ createdAt: dateA }, { createdAt: dateB }) => (
+                new Date(dateA) - new Date(dateB)
+            ));
+        }
+        return utterances;
+    }
+
     render() {
         const columns = this.getColumns();
-        const { utterances } = this.props;
+        const sortedUtterances = this.sortUtterances();
         return (
             <Tab.Pane as='div'>
                 <div style={{ padding: '0px', background: '#fff' }}>
                     <ReactTable
-                        data={utterances}
+                        data={sortedUtterances}
                         columns={columns}
                         minRows={1}
                         style={{ overflow: 'visible' }}
@@ -289,4 +305,8 @@ ActivityDataTable.propTypes = {
     projectId: PropTypes.string.isRequired,
     outDatedUtteranceIds: PropTypes.array.isRequired,
     modelId: PropTypes.string.isRequired,
+    sortBy: PropTypes.string,
+};
+ActivityDataTable.defaultProps = {
+    sortBy: 'mostRecent',
 };

--- a/botfront/imports/ui/components/nlu/activity/style.import.less
+++ b/botfront/imports/ui/components/nlu/activity/style.import.less
@@ -75,3 +75,23 @@
         border-top: none !important;
     }
 }
+
+.ui.horizontal.segments.new-utterances-topbar {
+    border-style: none;
+    box-shadow: none;
+    padding: 0px;
+    margin-bottom: 0px;
+    .ui.segment.new-utterances-topbar-section{
+        border-style: none;
+        vertical-align: center;
+        padding: 0px;
+        .ui.segment.sort-utterances-wrapper{
+            max-width: 200px;
+            padding-top: 0.4em;
+            padding-bottom: 0px;
+            text-align: center;
+            height: 2.4em;
+
+        }
+    }
+}

--- a/botfront/imports/ui/components/nlu/activity/style.import.less
+++ b/botfront/imports/ui/components/nlu/activity/style.import.less
@@ -79,19 +79,47 @@
 .ui.horizontal.segments.new-utterances-topbar {
     border-style: none;
     box-shadow: none;
-    padding: 0px;
     margin-bottom: 0px;
     .ui.segment.new-utterances-topbar-section{
         border-style: none;
-        vertical-align: center;
         padding: 0px;
-        .ui.segment.sort-utterances-wrapper{
-            max-width: 200px;
-            padding-top: 0.4em;
-            padding-bottom: 0px;
-            text-align: center;
-            height: 2.4em;
-
+        .angle.double.icon{
+            background:rgba(0,0,0,0);
+        }
+        .ui.buttons.sort-dropdown{
+            &:hover{
+                border-color: rgba(0,0,0,0.25);
+            }
+            .ui.dropdown.button.icon{
+                padding:0px;
+                &.active{
+                    background:rgba(0,0,0,0) !important; //required to overide semantic ui
+                }
+                .ui.segment.button.sort-dropdown-trigger{
+                    //alignment
+                    text-align: left;
+                    // border decoration
+                    border-style: none;
+                    // color and background
+                    color: rgba(0,0,0,.87) !important; // required to overide semantic ui
+                    // overflow
+                    text-overflow: ellipsis;
+                    overflow: hidden;
+                    white-space: nowrap;
+                    //padding
+                    padding-top: 0.8em;
+                    padding-bottom: 0px;
+                    padding-right: 0em;
+                    // size
+                    height: 2.4em;
+                    width: 160px;
+                }
+                .dropdown.icon{
+                    padding-top: 0.9em;
+                    padding-left: 0em;
+                    padding-right: 1em;
+                }
+            }
         }
     }
 }

--- a/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
@@ -17,7 +17,6 @@ import EntityReport from './EntityReport';
 import ExampleUtils from '../../utils/ExampleUtils';
 import { InputButtons } from './InputButtons.jsx';
 import { Evaluations } from '../../../../api/nlu_evaluation';
-import { ActivityCollection } from '../../../../api/activity';
 import { TestImport } from '../import-export/TestImport';
 import { Loading } from '../../utils/Utils';
 

--- a/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
@@ -93,6 +93,7 @@ class Evaluation extends React.Component {
 
     evaluate(incomingData) {
         this.setState({ evaluating: true });
+        const { data: dataFromState } = this.state;
         
         const {
             projectId,
@@ -100,8 +101,9 @@ class Evaluation extends React.Component {
                 _id: modelId,
             } = {},
         } = this.props;
+        let data = incomingData;
         if (!data) {
-        { data } = this.state;
+            data = dataFromState;
         }
         try {
             console.log(data.length);

--- a/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
@@ -100,7 +100,6 @@ class Evaluation extends React.Component {
         } = this.props;
 
         const { data } = this.state;
-        console.log(data);
 
         Meteor.call('rasa.evaluate.nlu', modelId, projectId, data, (err) => {
             this.setState({ evaluating: false });
@@ -137,7 +136,6 @@ class Evaluation extends React.Component {
                     data: { rasa_nlu_data: { common_examples: validExamples, entity_synonyms: [], gazetter: [] } },
                     loading: false,
                 }, callback);
-                //  ? this.evaluate : () => { console.log('no callback'); }
             } else {
                 const message = (
                     <Message warning>
@@ -183,10 +181,7 @@ class Evaluation extends React.Component {
 
         let defaultSelection = 0;
         if (validationRender()) {
-            console.log('did validate');
             defaultSelection = 2;
-        } else {
-            console.log('not validate');
         }
 
         return (

--- a/botfront/imports/ui/components/nlu/evaluation/InputButtons.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/InputButtons.jsx
@@ -6,19 +6,19 @@ import { Button } from 'semantic-ui-react';
 export class InputButtons extends React.Component {
     constructor(props) {
         super(props);
-
+        const { selectedIndex, onDefaultLoad, operations } = props;
+        operations[selectedIndex](onDefaultLoad);
         this.state = {
-            toggle: 0,
+            toggle: selectedIndex,
         };
     }
 
-    componentWillMount() {
-        const { operations, defaultSelection, onDefaultLoad } = this.props;
-
-        this.setState({ toggle: defaultSelection });
-        operations[defaultSelection](onDefaultLoad);
-    }
-
+    // componentWillMount() {
+    //     const { operations, defaultSelection, onDefaultLoad } = this.props;
+    //     this.setState({ toggle: defaultSelection });
+    //     operations[defaultSelection](onDefaultLoad);
+    // }
+    
     handleClick(operation, index) {
         return () => {
             this.setState({ toggle: index });
@@ -57,9 +57,11 @@ InputButtons.propTypes = {
     operations: PropTypes.arrayOf(PropTypes.func).isRequired,
     defaultSelection: PropTypes.number,
     onDefaultLoad: PropTypes.func,
+    selectedIndex: PropTypes.number,
 };
 
 InputButtons.defaultProps = {
     defaultSelection: 0,
+    selectedIndex: 0,
     onDefaultLoad: () => {},
 };

--- a/botfront/imports/ui/components/nlu/models/IntentViewer.jsx
+++ b/botfront/imports/ui/components/nlu/models/IntentViewer.jsx
@@ -156,7 +156,7 @@ class IntentNameEditor extends React.Component {
                 {intent}
             </Label>
         ) : (
-            <Label color='grey' style={style} basic>
+            <Label color='grey' style={style} basic data-cy='null-nlu-table-intent'>
                 -
             </Label>
         );

--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -45,11 +45,13 @@ import { Projects } from '../../../../api/project/project.collection';
 class NLUModel extends React.Component {
     constructor(props) {
         super(props);
-
-        const { openTo: { subPage, isActivityLinkRender } } = props;
+        const { location: { state: incomingState } } = props;
 
         this.state = {
-            activeItem: subPage, ...NLUModel.getDerivedStateFromProps(props), modelId: '', activityLinkRender: isActivityLinkRender,
+            activeItem: incomingState && incomingState.isActivityLinkRender === true ? 'evaluation' : 'data',
+            ...NLUModel.getDerivedStateFromProps(props),
+            modelId: '',
+            activityLinkRender: (incomingState && incomingState.isActivityLinkRender) || false,
         };
     }
 
@@ -384,7 +386,7 @@ NLUModel.propTypes = {
     models: PropTypes.array,
     projectDefaultLanguage: PropTypes.string,
     project: PropTypes.object,
-    openTo: PropTypes.object,
+    location: PropTypes.object.isRequired,
 };
 
 NLUModel.defaultProps = {
@@ -397,7 +399,6 @@ NLUModel.defaultProps = {
     projectId: '',
     model: {},
     project: {},
-    openTo: { subPage: 'data', isActivityLinkRender: false },
 };
 
 const handleDefaultRoute = (projectId) => {

--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -46,8 +46,12 @@ class NLUModel extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = { activeItem: 'data', ...NLUModel.getDerivedStateFromProps(props), modelId: '' };
-        this.activityLinkRender = false;
+        const { openTo: { subPage, isActivityLinkRender } } = props;
+
+        this.state = {
+            activeItem: subPage, ...NLUModel.getDerivedStateFromProps(props), modelId: '',
+        };
+        this.activityLinkRender = isActivityLinkRender || false;
     }
 
     static getDerivedStateFromProps(props) {
@@ -271,7 +275,7 @@ class NLUModel extends React.Component {
             ready,
         } = this.props;
         const {
-            activeItem, instance, entities, intents,
+            activeItem, instance, entities, intents, subPageInitialState,
         } = this.state;
         if (!project) return null;
         if (!model) return null;
@@ -362,7 +366,7 @@ class NLUModel extends React.Component {
                     <br />
                     <br />
                     {activeItem === 'data' && <Tab menu={{ pointing: true, secondary: true }} panes={this.getNLUSecondaryPanes()} />}
-                    {activeItem === 'evaluation' && <Evaluation model={model} projectId={projectId} validationRender={this.validationRender} />}
+                    {activeItem === 'evaluation' && <Evaluation model={model} projectId={projectId} validationRender={this.validationRender} initialState={subPageInitialState} />}
                     {activeItem === 'settings' && <Tab menu={{ pointing: true, secondary: true }} panes={this.getSettingsSecondaryPanes()} />}
                     {activeItem === 'activity' && <Activity project={project} modelId={modelId} entities={entities} intents={intents} linkRender={this.linkRender} instance={instance} />}
                 </Container>
@@ -381,6 +385,7 @@ NLUModel.propTypes = {
     models: PropTypes.array,
     projectDefaultLanguage: PropTypes.string,
     project: PropTypes.object,
+    openTo: PropTypes.object,
 };
 
 NLUModel.defaultProps = {
@@ -393,6 +398,7 @@ NLUModel.defaultProps = {
     projectId: '',
     model: {},
     project: {},
+    openTo: { subPage: 'evaluation', isActivityLinkRender: true },
 };
 
 const handleDefaultRoute = (projectId) => {
@@ -409,7 +415,6 @@ const handleDefaultRoute = (projectId) => {
 
 const NLUDataLoaderContainer = withTracker((props) => {
     const { params: { model_id: modelId, project_id: projectId } = {} } = props;
-    console.log(modelId);
 
     const {
         name,

--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -84,7 +84,7 @@ class NLUModel extends React.Component {
     validationRender = () => {
         const { activityLinkRender } = this.state;
         if (activityLinkRender === true) {
-            this.setState({activityLinkRender: false });
+            this.setState({ activityLinkRender: false });
             return true;
         }
         return false;

--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -49,9 +49,8 @@ class NLUModel extends React.Component {
         const { openTo: { subPage, isActivityLinkRender } } = props;
 
         this.state = {
-            activeItem: subPage, ...NLUModel.getDerivedStateFromProps(props), modelId: '',
+            activeItem: subPage, ...NLUModel.getDerivedStateFromProps(props), modelId: '', activityLinkRender: isActivityLinkRender,
         };
-        this.activityLinkRender = isActivityLinkRender || false;
     }
 
     static getDerivedStateFromProps(props) {
@@ -79,15 +78,15 @@ class NLUModel extends React.Component {
 
     linkRender = () => {
         this.activityLinkRender = true;
-        this.setState({ activeItem: 'evaluation' });
+        this.setState({ activeItem: 'evaluation', activityLinkRender: true });
     };
 
     validationRender = () => {
-        if (this.activityLinkRender) {
-            this.activityLinkRender = false;
+        const { activityLinkRender } = this.state;
+        if (activityLinkRender === true) {
+            this.setState({activityLinkRender: false });
             return true;
         }
-
         return false;
     };
 
@@ -398,7 +397,7 @@ NLUModel.defaultProps = {
     projectId: '',
     model: {},
     project: {},
-    openTo: { subPage: 'evaluation', isActivityLinkRender: true },
+    openTo: { subPage: 'data', isActivityLinkRender: false },
 };
 
 const handleDefaultRoute = (projectId) => {

--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -41,6 +41,8 @@ import API from './API';
 import { GlobalSettings } from '../../../../api/globalSettings/globalSettings.collection';
 import { Projects } from '../../../../api/project/project.collection';
 
+import { extractEntities } from './nluModel.utils';
+
 class NLUModel extends React.Component {
     constructor(props) {
         super(props);
@@ -437,17 +439,8 @@ const NLUDataLoaderContainer = withTracker((props) => {
     const { training_data: { common_examples = [] } = {} } = model;
     const instances = Instances.find({ projectId }).fetch();
     const intents = sortBy(uniq(common_examples.map(e => e.intent)));
-    const entities = [];
+    const entities = extractEntities(common_examples);
     const settings = GlobalSettings.findOne({}, { fields: { 'settings.public.chitChatProjectId': 1 } });
-    common_examples.forEach((e) => {
-        if (e.entities) {
-            e.entities.forEach((ent) => {
-                if (entities.indexOf(ent.entity) === -1) {
-                    entities.push(ent.entity);
-                }
-            });
-        }
-    });
 
     if (!name) return browserHistory.replace({ pathname: '/404' });
     const nluModelLanguages = getPublishedNluModelLanguages(nlu_models, true);

--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -24,7 +24,6 @@ import { Instances } from '../../../../api/instances/instances.collection';
 import NluDataTable from './NluDataTable';
 import NLUPlayground from '../../example_editor/NLUPlayground';
 import Evaluation from '../evaluation/Evaluation';
-import Activity from '../activity/Activity';
 import ChitChat from './ChitChat';
 import IntentBulkInsert from './IntentBulkInsert';
 import Synonyms from '../../synonyms/Synonyms';
@@ -76,11 +75,6 @@ class NLUModel extends React.Component {
         const { model: { training_data: { common_examples, entity_synonyms } = {} } = {} } = props;
         if (!common_examples) return [];
         return common_examples.map(e => _appendSynonymsToText(e, entity_synonyms));
-    };
-
-    linkRender = () => {
-        this.activityLinkRender = true;
-        this.setState({ activeItem: 'evaluation', activityLinkRender: true });
     };
 
     validationRender = () => {
@@ -263,9 +257,6 @@ class NLUModel extends React.Component {
         const {
             projectId,
             model,
-            model: {
-                _id: modelId,
-            } = {},
             project,
             project: {
                 training: {
@@ -276,7 +267,7 @@ class NLUModel extends React.Component {
             ready,
         } = this.props;
         const {
-            activeItem, instance, entities, intents, subPageInitialState,
+            activeItem, instance, entities, subPageInitialState,
         } = this.state;
         if (!project) return null;
         if (!model) return null;
@@ -306,10 +297,6 @@ class NLUModel extends React.Component {
             <div id='nlu-model'>
                 <Menu pointing secondary>
                     <Menu.Item header>{this.getHeader()}</Menu.Item>
-                    <Menu.Item name='activity' active={activeItem === 'activity'} onClick={this.handleMenuItemClick}>
-                        <Icon size='small' name='history' />
-                        {'Activity'}
-                    </Menu.Item>
                     <Menu.Item name='data' active={activeItem === 'data'} onClick={this.handleMenuItemClick} className='nlu-menu-training-data'>
                         <Icon size='small' name='database' />
                         {'Training Data'}
@@ -369,7 +356,6 @@ class NLUModel extends React.Component {
                     {activeItem === 'data' && <Tab menu={{ pointing: true, secondary: true }} panes={this.getNLUSecondaryPanes()} />}
                     {activeItem === 'evaluation' && <Evaluation model={model} projectId={projectId} validationRender={this.validationRender} initialState={subPageInitialState} />}
                     {activeItem === 'settings' && <Tab menu={{ pointing: true, secondary: true }} panes={this.getSettingsSecondaryPanes()} />}
-                    {activeItem === 'activity' && <Activity project={project} modelId={modelId} entities={entities} intents={intents} linkRender={this.linkRender} instance={instance} />}
                 </Container>
             </div>
         );

--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -409,6 +409,7 @@ const handleDefaultRoute = (projectId) => {
 
 const NLUDataLoaderContainer = withTracker((props) => {
     const { params: { model_id: modelId, project_id: projectId } = {} } = props;
+    console.log(modelId);
 
     const {
         name,

--- a/botfront/imports/ui/components/nlu/models/nluModel.utils.js
+++ b/botfront/imports/ui/components/nlu/models/nluModel.utils.js
@@ -1,0 +1,13 @@
+export const extractEntities = (examples) => {
+    const entities = [];
+    examples.forEach((e) => {
+        if (e.entities) {
+            e.entities.forEach((ent) => {
+                if (entities.indexOf(ent.entity) === -1) {
+                    entities.push(ent.entity);
+                }
+            });
+        }
+    });
+    return entities;
+};

--- a/botfront/imports/ui/components/project/ProjectSidebar.jsx
+++ b/botfront/imports/ui/components/project/ProjectSidebar.jsx
@@ -41,9 +41,6 @@ class ProjectSidebar extends React.Component {
                     <Link to={`/project/${projectId}/incoming`}>
                         <Menu.Item name='Incoming' icon='paper plane' />
                     </Link>
-                    <Link to={`/project/${projectId}/dialogue/conversations/p/1`}>
-                        <Menu.Item name='Conversations' icon='comments' />
-                    </Link>
                     <Link to={`/project/${projectId}/settings`}>
                         <Menu.Item name='Settings' icon='setting' />
                     </Link>

--- a/botfront/imports/ui/components/project/ProjectSidebar.jsx
+++ b/botfront/imports/ui/components/project/ProjectSidebar.jsx
@@ -35,11 +35,11 @@ class ProjectSidebar extends React.Component {
                             <Menu.Item name='Legacy NLU' icon='history' />
                         </Link>
                     )}
-                    <Link to={`/project/${projectId}/dialogue/templates`}>
-                        <Menu.Item name='Responses' icon='comment' />
-                    </Link>
                     <Link to={`/project/${projectId}/incoming`}>
                         <Menu.Item name='Incoming' icon='inbox' data-cy='incoming-page' />
+                    </Link>
+                    <Link to={`/project/${projectId}/dialogue/templates`}>
+                        <Menu.Item name='Responses' icon='comment' />
                     </Link>
                     <Link to={`/project/${projectId}/settings`}>
                         <Menu.Item name='Settings' icon='setting' />

--- a/botfront/imports/ui/components/project/ProjectSidebar.jsx
+++ b/botfront/imports/ui/components/project/ProjectSidebar.jsx
@@ -39,7 +39,7 @@ class ProjectSidebar extends React.Component {
                         <Menu.Item name='Responses' icon='comment' />
                     </Link>
                     <Link to={`/project/${projectId}/incoming`}>
-                        <Menu.Item name='Incoming' icon='paper plane' />
+                        <Menu.Item name='Incoming' icon='inbox' data-cy='incoming-page' />
                     </Link>
                     <Link to={`/project/${projectId}/settings`}>
                         <Menu.Item name='Settings' icon='setting' />

--- a/botfront/imports/ui/components/project/ProjectSidebar.jsx
+++ b/botfront/imports/ui/components/project/ProjectSidebar.jsx
@@ -39,7 +39,7 @@ class ProjectSidebar extends React.Component {
                         <Menu.Item name='Responses' icon='comment' />
                     </Link>
                     <Link to={`/project/${projectId}/Incoming`}>
-                        <Menu.Item name='Incoming' icon='comment' />
+                        <Menu.Item name='Incoming' icon='paper plane' />
                     </Link>
                     <Link to={`/project/${projectId}/dialogue/conversations/p/1`}>
                         <Menu.Item name='Conversations' icon='comments' />

--- a/botfront/imports/ui/components/project/ProjectSidebar.jsx
+++ b/botfront/imports/ui/components/project/ProjectSidebar.jsx
@@ -38,6 +38,9 @@ class ProjectSidebar extends React.Component {
                     <Link to={`/project/${projectId}/dialogue/templates`}>
                         <Menu.Item name='Responses' icon='comment' />
                     </Link>
+                    <Link to={`/project/${projectId}/Incoming`}>
+                        <Menu.Item name='Incoming' icon='comment' />
+                    </Link>
                     <Link to={`/project/${projectId}/dialogue/conversations/p/1`}>
                         <Menu.Item name='Conversations' icon='comments' />
                     </Link>
@@ -51,9 +54,9 @@ class ProjectSidebar extends React.Component {
                         <Menu.Item name='help' icon='bell' content='Get help' />
                     </a>
                     <Divider inverted />
-                        <Link to='/login'>
-                            <Menu.Item data-cy='signout' name='Sign out' icon='sign-out' />
-                        </Link>
+                    <Link to='/login'>
+                        <Menu.Item data-cy='signout' name='Sign out' icon='sign-out' />
+                    </Link>
                     <Divider inverted />
                 </Menu>
             </DocumentTitle>

--- a/botfront/imports/ui/components/project/ProjectSidebar.jsx
+++ b/botfront/imports/ui/components/project/ProjectSidebar.jsx
@@ -38,7 +38,7 @@ class ProjectSidebar extends React.Component {
                     <Link to={`/project/${projectId}/dialogue/templates`}>
                         <Menu.Item name='Responses' icon='comment' />
                     </Link>
-                    <Link to={`/project/${projectId}/Incoming`}>
+                    <Link to={`/project/${projectId}/incoming`}>
                         <Menu.Item name='Incoming' icon='paper plane' />
                     </Link>
                     <Link to={`/project/${projectId}/dialogue/conversations/p/1`}>


### PR DESCRIPTION
<!-- description of what you achieved -->

- I moved activity from nlu to a separate project sidebar tab called incoming
- I moved conversations into the incoming tab
- I fixed a bug where linking to evaluation from incoming would not open the right evaluation tab

test:
- should show available languages in the language selector
- it should be able to link to evaluation from new utterances
- it should be able to add new utterances to nlu
- should be able to invalidate utterances

If the feature is a refactor, please explain why your way is better
