### PR TITLE
Test/project porting

### DIFF
--- a/botfront/cypress.json
+++ b/botfront/cypress.json
@@ -12,7 +12,7 @@
     "numTestsKeptInMemory": 2 ,
     "viewportHeight": 900,
     "viewportWidth": 1800,
-    "ignoreTestFiles":["**/export-project.spec.js", "**/import-project.spec.js"],
+    "ignoreTestFiles":[],
     "env": {
         "RASA_URL": "http://localhost:5005",
         "API_URL": "http://localhost:8080",

--- a/botfront/cypress/integration/import_export_project/export-project.spec.js
+++ b/botfront/cypress/integration/import_export_project/export-project.spec.js
@@ -25,7 +25,7 @@ describe('Exporting a Project', function() {
     });
 
     describe('Export UI', function() {
-        it('should navigate the UI for exporting to Botfront', function() {
+        it('should be able to export a project with conversations', function() {
             cy.visit('/project/test_project/settings');
             cy.contains('Import/Export').click();
             cy.dataCy('port-project-menu')
@@ -46,7 +46,7 @@ describe('Exporting a Project', function() {
                 .should('have.attr', 'href')
                 .and('equal', `${Cypress.env('API_URL')}/project/test_project/export?output=json&conversations=true`);
         });
-        it('should link to the right url when exporting without conversations', function() {
+        it('should be able to export a project without conversations', function() {
             cy.visit('/project/test_project/settings');
             cy.contains('Import/Export').click();
             cy.dataCy('port-project-menu')

--- a/botfront/cypress/integration/import_export_project/export-project.spec.js
+++ b/botfront/cypress/integration/import_export_project/export-project.spec.js
@@ -1,6 +1,4 @@
 /* eslint-disable no-undef */
-const apiHost = 'http://localhost:8080';
-
 
 describe('Exporting a Project', function() {
     beforeEach(function() {
@@ -46,7 +44,31 @@ describe('Exporting a Project', function() {
                 .should('exist');
             cy.dataCy('export-link')
                 .should('have.attr', 'href')
-                .and('equal', `${apiHost}/project/test_project/export`);
+                .and('equal', `${Cypress.env('API_URL')}/project/test_project/export?output=json&conversations=true`);
+        });
+        it('should link to the right url when exporting without conversations', function() {
+            cy.visit('/project/test_project/settings');
+            cy.contains('Import/Export').click();
+            cy.dataCy('port-project-menu')
+                .find('.item')
+                .contains('Export')
+                .click();
+            cy.dataCy('export-type-dropdown')
+                .click()
+                .find('span')
+                .contains('Botfront')
+                .click();
+            cy.dataCy('conversation-toggle')
+                .click();
+            cy.wait(1000);
+            cy.dataCy('export-button')
+                .click();
+            cy.dataCy('export-success-message')
+                .contains('Your project has been successfully exported for Botfront!')
+                .should('exist');
+            cy.dataCy('export-link')
+                .should('have.attr', 'href')
+                .and('equal', `${Cypress.env('API_URL')}/project/test_project/export?output=json&conversations=false`);
         });
         it('should display an error message when the api request fails', function() {
             cy.visit('/project/test_project/settings');
@@ -61,7 +83,7 @@ describe('Exporting a Project', function() {
             cy.dataCy('docker-api-host')
                 .find('input')
                 .clear()
-                .type(`${apiHost}1{enter}`);
+                .type(`${Cypress.env('API_URL')}1{enter}`);
             cy.visit('/project/test_project/settings');
             cy.contains('Import/Export').click();
             cy.dataCy('port-project-menu')

--- a/botfront/cypress/integration/import_export_project/export-project.spec.js
+++ b/botfront/cypress/integration/import_export_project/export-project.spec.js
@@ -18,7 +18,7 @@ describe('Exporting a Project', function() {
         cy.dataCy('docker-api-host')
             .find('input')
             .clear()
-            .type(`${apiHost}{enter}`);
+            .type(`${Cypress.env('API_URL')}{enter}`);
     });
 
     afterEach(function() {

--- a/botfront/cypress/integration/import_export_project/import-project.spec.js
+++ b/botfront/cypress/integration/import_export_project/import-project.spec.js
@@ -6,7 +6,7 @@ const slotType = 'bool';
 const intentExampleText = 'what\'s the date';
 
 const intent = 'date';
-const nExamplesOfIntent = 3;
+const nExamples = 8;
 
 const responseIntent = 'utter_g2FiL5tLA';
 const responseText = 'which account would you like to access';
@@ -147,6 +147,7 @@ describe('Importing a project', function() {
                 .click();
             cy.contains('Backup Failed').should('exist');
         });
+
         it('should import the right number and names of story groups', function() {
             cy.visit('/project/test_project/stories');
             cy.dataCy('browser-item')
@@ -171,13 +172,15 @@ describe('Importing a project', function() {
             cy.dataCy('browser-item')
                 .contains(storyGroupName)
                 .should('exist');
-            cy.dataCy('browser-item').should('have.lengthOf', 3);
+            cy.dataCy('browser-item').should('have.lengthOf', 4);
         });
-        
+
         it('should import story contents', function() {
             importProject();
 
             cy.visit('/project/test_project/stories');
+            cy.dataCy('toggle-md')
+                .click();
             cy.dataCy('browser-item')
                 .contains(storyGroupName)
                 .click();
@@ -195,7 +198,7 @@ describe('Importing a project', function() {
             importProject();
 
             cy.visit('/project/test_project/stories');
-            cy.dataCy('slots-tab')
+            cy.dataCy('slots-modal')
                 .click();
             cy.dataCy('slot-editor').should('have.lengthOf', 1);
             cy.dataCy('slot-editor')
@@ -208,28 +211,16 @@ describe('Importing a project', function() {
         });
         it('should import the right number of examples for an intent', function() {
             importProject();
-
             cy.visit('/project/test_project/nlu/models');
             cy.contains(intentExampleText)
                 .closest('.rt-tr')
                 .contains(intent)
                 .should('exist');
-            for (let iDeleteNLU = 0; iDeleteNLU < nExamplesOfIntent; iDeleteNLU += 1) {
-                cy.dataCy('intent-label')
-                    .contains(intent)
-                    .closest('.rt-tr')
-                    .find('.trash')
-                    .click({ force: true });
-                cy.contains('Insert many').click();
-                cy.contains('Examples').click();
-            }
+            cy.dataCy('intent-label')
+                .should('have.lengthOf', nExamples);
             cy.contains('Insert many').click();
             cy.contains('Examples').click();
-            cy.dataCy('intent-label')
-                .contains(intent)
-                .should('not.exist');
         });
-        
         it('should import all responses', function() {
             importProject();
 

--- a/botfront/imports/ui/components/settings/ExportProject.jsx
+++ b/botfront/imports/ui/components/settings/ExportProject.jsx
@@ -22,26 +22,36 @@ const ExportProject = ({
     const [errorMessage, setErrorMessage] = useState({ header: 'Export Failed', text: 'There was an unexpected error in the api request.' });
     const [includeConversations, setIncludeConversations] = useState(true);
 
-    const exportTypeOptions = [
-        {
-            key: 'botfront',
-            text: 'Export for Botfront',
-            value: 'botfront',
-            successText: 'Your project has been successfully exported for Botfront!',
-            content: (
+    const getExportTypeOptions = () => (
+        [
+            {
+                key: 'botfront',
+                text: 'Export for Botfront',
+                value: 'botfront',
+                successText: 'Your project has been successfully exported for Botfront!',
+            },
+            // {
+            //     key: 'rasa',
+            //     text: 'Export for Rasa/Rasa X',
+            //     value: 'rasa',
+            //     successText: 'Your project has been successfully exported for Rasa/Rasa X!',
+            // },
+        ]
+    );
+
+    const getSuccessMessageContent = () => {
+        if (exportType.value === 'botfront') {
+            return (
                 <p>
                     If your download does not start within 5 seconds click{' '}
-                    <a href={`${apiHost}/project/${projectId}/export`} data-cy='export-link'>here </a>
+                    <a href={`${apiHost}/project/${projectId}/export?output=json&conversations=${includeConversations}`} data-cy='export-link'>here </a>
                     to retry.
-                </p>),
-        },
-        {
-            key: 'rasa',
-            text: 'Export for Rasa/Rasa X',
-            value: 'rasa',
-            successText: 'Your project has been successfully exported for Rasa/Rasa X!',
-        },
-    ];
+                </p>
+            );
+        }
+        return <></>;
+    };
+
 
     const getLanguageOptions = () => (
         projectLanguages.map(({ value, text }) => ({
@@ -128,7 +138,7 @@ const ExportProject = ({
     };
 
     const handleDropdownOnChange = (x, { value }) => {
-        setExportType(exportTypeOptions.find(option => option.value === value) || {});
+        setExportType(getExportTypeOptions().find(option => option.value === value) || {});
     };
 
     if (ExportSuccessful === true) {
@@ -138,7 +148,7 @@ const ExportProject = ({
                 positive
                 icon='check circle'
                 header={exportType.successText}
-                content={<>{exportType.content}</>}
+                content={getSuccessMessageContent()}
             />
         );
     }
@@ -160,7 +170,7 @@ const ExportProject = ({
                 key='format'
                 className='export-option'
                 options={
-                    exportTypeOptions.map(({ value, text, key }) => ({ value, text, key }))
+                    getExportTypeOptions().map(({ value, text, key }) => ({ value, text, key }))
                 }
                 placeholder='Select a format'
                 selection
@@ -175,6 +185,7 @@ const ExportProject = ({
                         onChange={() => { setIncludeConversations(!includeConversations); }}
                         label='Export Conversations'
                         className='export-option'
+                        data-cy='conversation-toggle'
                     />
                     <br />
                 </>

--- a/botfront/imports/ui/components/settings/ExportProject.jsx
+++ b/botfront/imports/ui/components/settings/ExportProject.jsx
@@ -30,12 +30,12 @@ const ExportProject = ({
                 value: 'botfront',
                 successText: 'Your project has been successfully exported for Botfront!',
             },
-            // {
-            //     key: 'rasa',
-            //     text: 'Export for Rasa/Rasa X',
-            //     value: 'rasa',
-            //     successText: 'Your project has been successfully exported for Rasa/Rasa X!',
-            // },
+            {
+                key: 'rasa',
+                text: 'Export for Rasa/Rasa X',
+                value: 'rasa',
+                successText: 'Your project has been successfully exported for Rasa/Rasa X!',
+            },
         ]
     );
 

--- a/botfront/imports/ui/components/settings/ExportProject.jsx
+++ b/botfront/imports/ui/components/settings/ExportProject.jsx
@@ -69,6 +69,11 @@ const ExportProject = ({
             if (data) {
                 const blob = new Blob([data], { type: 'text/plain;charset=utf-8' });
                 const filename = `BotfrontProject_${projectId}.json`;
+                if (window.Cypress) {
+                    setExportSuccessful(true);
+                    setLoading(false);
+                    return;
+                }
                 saveAs(blob, filename);
                 setExportSuccessful(true);
                 setLoading(false);

--- a/botfront/imports/ui/components/settings/ImportProject.jsx
+++ b/botfront/imports/ui/components/settings/ImportProject.jsx
@@ -84,6 +84,10 @@ const ImportProject = ({
             if (data) {
                 const blob = new Blob([data], { type: 'text/plain;charset=utf-8' });
                 const filename = `BotfrontProjectBackup_${projectId}.json`;
+                if (window.Cypress) {
+                    setbackupSuccess(true);
+                    return;
+                }
                 saveAs(blob, filename);
                 setbackupSuccess(true);
                 return;
@@ -159,7 +163,11 @@ const ImportProject = ({
                 {backupSuccess === true && (
                     <p className='plain-text-message'>
                         If the backup download did not automatically start after 10 seconds, click
-                        <a href={`${apiHost}/project/${projectId}/export?output=json&conversations=${includeConvos}`}> here</a> to retry.
+                        <a
+                            href={`${apiHost}/project/${projectId}/export?output=json&conversations=${includeConvos}`}
+                            data-cy='backup-link'
+                        > here
+                        </a> to retry.
                         <br />Please verify that the backup has downloaded before continuing.
                     </p>
                 )}
@@ -176,6 +184,7 @@ const ImportProject = ({
                         warning
                         icon='exclamation circle'
                         header='Warning!'
+                        data-cy='skiped-backup-warning'
                         content={(
                             <>
                                 All your current project data will be permanently overwritten and erased when you click
@@ -195,11 +204,11 @@ const ImportProject = ({
                 { backupSuccess === undefined && botfrontFileSuccess && (
                     <>
                         <Button.Group>
-                            <Button onClick={() => { backupProject(true); setIncludeConvos(true); }} className='export-option' data-cy='export-button'>
+                            <Button onClick={() => { backupProject(true); setIncludeConvos(true); }} className='export-option' data-cy='export-with-conversations'>
                                 Download backup with conversations
                             </Button>
                             <Button.Or />
-                            <Button onClick={() => { backupProject(false); setIncludeConvos(false); }} className='export-option'>
+                            <Button onClick={() => { backupProject(false); setIncludeConvos(false); }} className='export-option' data-cy='export-without-conversations'>
                                 Download backup without conversations
                             </Button>
                             <Button.Or />

--- a/botfront/package-lock.json
+++ b/botfront/package-lock.json
@@ -6300,8 +6300,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -6503,8 +6502,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -15383,7 +15381,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isequal": {
@@ -16011,7 +16009,7 @@
       "dependencies": {
         "asn1.js": {
           "version": "4.10.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "requires": {
             "bn.js": "^4.0.0",
@@ -16021,7 +16019,7 @@
         },
         "assert": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
           "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
           "requires": {
             "util": "0.10.3"
@@ -16029,22 +16027,22 @@
         },
         "base64-js": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
           "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
         },
         "bn.js": {
           "version": "4.11.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         },
         "brorand": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
           "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browserify-aes": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
             "buffer-xor": "^1.0.3",
@@ -16057,7 +16055,7 @@
         },
         "browserify-cipher": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
           "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
           "requires": {
             "browserify-aes": "^1.0.4",
@@ -16067,7 +16065,7 @@
         },
         "browserify-des": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
           "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
           "requires": {
             "cipher-base": "^1.0.1",
@@ -16077,16 +16075,16 @@
         },
         "browserify-rsa": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+          "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "requires": {
-            "bn.js": "^4.1.0",
-            "randombytes": "^2.0.1"
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
           }
         },
         "browserify-sign": {
           "version": "4.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
           "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
           "requires": {
             "bn.js": "^4.1.1",
@@ -16100,7 +16098,7 @@
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "requires": {
             "pako": "~0.2.0"
@@ -16108,7 +16106,7 @@
         },
         "buffer": {
           "version": "4.9.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",
@@ -16118,17 +16116,17 @@
         },
         "buffer-xor": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
           "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "builtin-status-codes": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
           "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
         },
         "cipher-base": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "requires": {
             "inherits": "^2.0.1",
@@ -16137,7 +16135,7 @@
         },
         "console-browserify": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "requires": {
             "date-now": "^0.1.4"
@@ -16145,17 +16143,17 @@
         },
         "constants-browserify": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
           "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "create-ecdh": {
           "version": "4.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
           "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
           "requires": {
             "bn.js": "^4.1.0",
@@ -16164,7 +16162,7 @@
         },
         "create-hash": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "requires": {
             "cipher-base": "^1.0.1",
@@ -16176,7 +16174,7 @@
         },
         "create-hmac": {
           "version": "1.1.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "requires": {
             "cipher-base": "^1.0.3",
@@ -16189,7 +16187,7 @@
         },
         "crypto-browserify": {
           "version": "3.12.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
           "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
           "requires": {
             "browserify-cipher": "^1.0.0",
@@ -16207,12 +16205,12 @@
         },
         "date-now": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
           "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
         },
         "des.js": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
           "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
           "requires": {
             "inherits": "^2.0.1",
@@ -16221,7 +16219,7 @@
         },
         "diffie-hellman": {
           "version": "5.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
           "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
           "requires": {
             "bn.js": "^4.1.0",
@@ -16231,12 +16229,12 @@
         },
         "domain-browser": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
           "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
         },
         "elliptic": {
           "version": "6.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
           "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
           "requires": {
             "bn.js": "^4.4.0",
@@ -16250,12 +16248,12 @@
         },
         "events": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
           "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "evp_bytestokey": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "requires": {
             "md5.js": "^1.3.4",
@@ -16264,7 +16262,7 @@
         },
         "hash-base": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
             "inherits": "^2.0.1",
@@ -16273,7 +16271,7 @@
         },
         "hash.js": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "requires": {
             "inherits": "^2.0.3",
@@ -16282,14 +16280,14 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "hmac-drbg": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "requires": {
             "hash.js": "^1.0.3",
@@ -16299,70 +16297,61 @@
         },
         "https-browserify": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
           "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
         },
         "ieee754": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
           "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
         },
         "indexof": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
           "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "inherits": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "md5.js": {
           "version": "1.3.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
           "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1"
           }
         },
-        "miller-rabin": {
-          "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-          "requires": {
-            "bn.js": "^4.0.0",
-            "brorand": "^1.0.1"
-          }
-        },
         "minimalistic-assert": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
           "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
           "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "os-browserify": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
           "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8="
         },
         "pako": {
           "version": "0.2.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
           "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
         },
         "parse-asn1": {
           "version": "5.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
           "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
           "requires": {
             "asn1.js": "^4.0.0",
@@ -16374,12 +16363,12 @@
         },
         "path-browserify": {
           "version": "0.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
         },
         "pbkdf2": {
           "version": "3.0.16",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
           "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
           "requires": {
             "create-hash": "^1.1.2",
@@ -16391,17 +16380,17 @@
         },
         "process": {
           "version": "0.11.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "public-encrypt": {
           "version": "4.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
           "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
           "requires": {
             "bn.js": "^4.1.0",
@@ -16413,22 +16402,22 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "querystring": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
           "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
         },
         "randombytes": {
           "version": "2.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
           "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
           "requires": {
             "safe-buffer": "^5.1.0"
@@ -16436,7 +16425,7 @@
         },
         "randomfill": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
           "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
           "requires": {
             "randombytes": "^2.0.5",
@@ -16445,7 +16434,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -16459,14 +16448,14 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             }
           }
         },
         "ripemd160": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "requires": {
             "hash-base": "^3.0.0",
@@ -16475,12 +16464,12 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "sha.js": {
           "version": "2.4.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
             "inherits": "^2.0.1",
@@ -16489,7 +16478,7 @@
         },
         "stream-browserify": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "requires": {
             "inherits": "~2.0.1",
@@ -16498,7 +16487,7 @@
         },
         "stream-http": {
           "version": "2.8.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
           "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
           "requires": {
             "builtin-status-codes": "^3.0.0",
@@ -16510,7 +16499,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -16518,7 +16507,7 @@
         },
         "timers-browserify": {
           "version": "1.4.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
           "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
           "requires": {
             "process": "~0.11.0"
@@ -16526,17 +16515,17 @@
         },
         "to-arraybuffer": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
           "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
         },
         "url": {
           "version": "0.11.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
           "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
           "requires": {
             "punycode": "1.3.2",
@@ -16545,14 +16534,14 @@
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -16560,12 +16549,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
           "requires": {
             "indexof": "0.0.1"
@@ -16573,7 +16562,7 @@
         },
         "xtend": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
@@ -16614,7 +16603,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"


### PR DESCRIPTION
<!-- description of what you achieved -->

I enabled the project import, and project export tests
I prevented the project backup from downloading when running botfront in cypress
I refactored the import project test to test the new options to export with/without conversations

tests:
Export
- should be able to export a project with conversations
- should be able to export a project without conversations
- should see an error message when the export fails
Import
- link to the right url when backing up with conversations
- link to the right url when backing up without conversations
- display a warning message when the user skips creating a backup
- displays a error message when the backup fails
- should import the right number and names of story groups
- should import story contents
- should import slots with the right type and name
- should import the right number of examples for an intent
- should import all responses
- should include entities in the intent example imports
