### PR TITLE
fix: nlu training button permanatly disabled

### DIFF
--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -66,7 +66,7 @@ class NLUModel extends React.Component {
         } = props;
         return {
             examples: ready ? NLUModel.getExamplesWithExtraSynonyms(props) : [],
-            instance: find(instances, i => i._id === instance),
+            instance: find(instances, i => i._id === instance) || (instances && instances[0]),
             intents,
             entities,
             ready,


### PR DESCRIPTION
<!-- description of what you achieved -->
- If the instance in project settings is not defined, default to the first instance that matches the project Id.

This solves an issue where the train button in the NLU page was permanently greyed out after an import
