### PR TITLE
Refactor/intro stories disable edit

### DIFF
--- a/botfront/cypress/integration/stories/story_groups.spec.js
+++ b/botfront/cypress/integration/stories/story_groups.spec.js
@@ -11,7 +11,7 @@ describe('stories', function() {
     beforeEach(function() {
         cy.createProject('bf', 'My Project', 'fr').then(() => cy.login());
     });
-    
+
     it('should be possible to delete a story group', function() {
         cy.visit('/project/bf/stories');
         cy.dataCy('toggle-md').click({ force: true });
@@ -26,6 +26,17 @@ describe('stories', function() {
         cy.dataCy('browser-item')
             .find('span')
             .contains(storyGroupOne)
+            .should('not.exist');
+    });
+
+    it('should not be possible to edit the Intro stories group', function() {
+        cy.visit('/project/bf/stories');
+        // hover the intro story group
+        cy.contains('Intro stories')
+            .trigger('mouseover');
+        // it should not have an edit menu
+        cy.contains('Intro stories')
+            .find('[data-cy=ellipsis-menu]')
             .should('not.exist');
     });
 

--- a/botfront/imports/ui/components/stories/StoryGroupBrowser.jsx
+++ b/botfront/imports/ui/components/stories/StoryGroupBrowser.jsx
@@ -88,7 +88,7 @@ class StoryGroupBrowser extends React.Component {
         <Popup size='mini' inverted content={tooltip} trigger={trigger} />
     );
 
-    getItems = (slice) => {
+    getItems = (slice, options = {}) => {
         const {
             data,
             index: indexProp,
@@ -99,6 +99,9 @@ class StoryGroupBrowser extends React.Component {
             changeName,
             stories,
         } = this.props;
+        const {
+            isIntroStory,
+        } = options;
         return data.slice(...slice)
             .map((item, index) => (
                 <StoryGroupItem
@@ -109,7 +112,7 @@ class StoryGroupBrowser extends React.Component {
                     nameAccessor={nameAccessor}
                     handleClickMenuItem={() => this.handleClickMenuItem(index + slice[0])}
                     selectAccessor={selectAccessor}
-                    allowEdit={allowEdit}
+                    allowEdit={allowEdit && !isIntroStory}
                     handleToggle={e => this.handleToggle(e, item)}
                     saving={saving}
                     changeName={changeName}
@@ -196,7 +199,7 @@ class StoryGroupBrowser extends React.Component {
                         ))}
                 {data.length && (
                     <Menu vertical fluid>
-                        {this.getItems([0, 1])}
+                        {this.getItems([0, 1], { isIntroStory: true })}
                     </Menu>
                 )}
                 {data.length > 1 && (


### PR DESCRIPTION
<!-- description of what you achieved -->
- I removed the ellipsis from the intro story group menu item
- I tested that the ellipsis do not exist for the intro story group menu item

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
