### PR TITLE
Refactor/order story groups

### DIFF
--- a/botfront/cypress/integration/stories/persist-state.spec.js
+++ b/botfront/cypress/integration/stories/persist-state.spec.js
@@ -17,20 +17,40 @@ describe('stories state persisting', function() {
     //     positions.map(p => cy.contains(group).click(p, { force: true }));
     // }
 
+    it('should remember the selected story group when a story group is selected by creating a story group', function() {
+        cy.visit('/project/bf/stories');
+        cy.dataCy('add-item').click({ force: true });
+        cy.dataCy('add-item-input')
+            .find('input')
+            .type(`${storyGroupOne}{enter}`);
+        cy.dataCy('browser-item').contains(storyGroupOne).parent().should('have.class', 'selected-blue');
+        cy.dataCy('add-item').click({ force: true });
+        cy.dataCy('add-item-input')
+            .find('input')
+            .type(`${storyGroupTwo}{enter}`);
+        cy.dataCy('browser-item').contains(storyGroupTwo).parent().should('have.class', 'selected-blue');
+        cy.contains('NLU').click({ force: true });
+        cy.contains('Stories').click({ force: true });
+        cy.wait(200);
+        cy.dataCy('browser-item').contains(storyGroupTwo).parent().should('have.class', 'selected-blue');
+    });
     it('should remember the last story group clicked', function() {
         cy.visit('/project/bf/stories');
         cy.dataCy('add-item').click({ force: true });
         cy.dataCy('add-item-input')
             .find('input')
             .type(`${storyGroupOne}{enter}`);
-        cy.dataCy('browser-item').contains(storyGroupOne).parents().should('have.class', 'selected-blue');
+        cy.dataCy('browser-item').contains(storyGroupOne).parent().should('have.class', 'selected-blue');
         cy.dataCy('add-item').click({ force: true });
         cy.dataCy('add-item-input')
             .find('input')
             .type(`${storyGroupTwo}{enter}`);
-        cy.dataCy('browser-item').contains(storyGroupTwo).parents().should('have.class', 'selected-blue');
+        cy.dataCy('browser-item').contains(storyGroupTwo).parent().should('have.class', 'selected-blue');
+        cy.dataCy('browser-item').contains(storyGroupOne).click();
+        cy.dataCy('browser-item').contains(storyGroupOne).parent().should('have.class', 'selected-blue');
         cy.contains('NLU').click({ force: true });
         cy.contains('Stories').click({ force: true });
-        cy.dataCy('browser-item').contains(storyGroupTwo).parents().should('have.class', 'selected-blue');
+        cy.wait(200);
+        cy.dataCy('browser-item').contains(storyGroupOne).parent().should('have.class', 'selected-blue');
     });
 });

--- a/botfront/imports/ui/components/stories/Stories.jsx
+++ b/botfront/imports/ui/components/stories/Stories.jsx
@@ -64,15 +64,6 @@ function Stories(props) {
         }
     }, [switchToGroupByIdNext]);
 
-    // useEffect(() => {
-    //     if (!storyGroups[storyGroupCurrent] && switchToGroupByIdNext === '') {
-    //         if (storyGroups[storyGroupCurrent + 1]) {
-    //             changeStoryGroup(storyGroupCurrent + 1);
-    //         }
-    //         // changeStoryGroup(storyGroupCurrent - 1);
-    //     }
-    // }, [storyGroups.length]);
-
     // By passing an empty array as the second argument to this useEffect
     // We make it so UseEffect is only called once, onMount
     useEffect(() => {
@@ -351,6 +342,24 @@ const StoriesWithTracker = withTracker((props) => {
         templates,
     };
 
+    // fetch and sort story groups
+    const unsortedStoryGroups = StoryGroups.find({}, { sort: [['introStory', 'desc']] }).fetch();
+    const sortedStoryGroups = unsortedStoryGroups // sorted on the frontend
+        .slice(1)
+        .sort((storyGroupA, storyGroupB) => {
+            const nameA = storyGroupA.name.toUpperCase();
+            const nameB = storyGroupB.name.toUpperCase();
+            if (nameA < nameB) {
+                return -1;
+            }
+            if (nameA > nameB) {
+                return 1;
+            }
+            return 0;
+        });
+    // unsortedStoryGroups[0] is the intro story group
+    const storyGroups = [unsortedStoryGroups[0], ...sortedStoryGroups];
+
     if (!workingLanguage && defaultLanguage) changeWorkingLanguage(defaultLanguage);
 
     return {
@@ -360,7 +369,7 @@ const StoriesWithTracker = withTracker((props) => {
             && instancesHandler.ready()
             && slotsHandler.ready()
             && storiesHandler.ready(),
-        storyGroups: StoryGroups.find({}, { sort: [['introStory', 'desc']] }).fetch(),
+        storyGroups,
         slots: Slots.find({}).fetch(),
         instance,
         project,

--- a/botfront/imports/ui/components/stories/Stories.jsx
+++ b/botfront/imports/ui/components/stories/Stories.jsx
@@ -64,12 +64,14 @@ function Stories(props) {
         }
     }, [switchToGroupByIdNext]);
 
-    useEffect(() => {
-        if (!storyGroups[storyGroupCurrent] && switchToGroupByIdNext === '') {
-            if (storyGroups[storyGroupCurrent + 1]) changeStoryGroup(storyGroupCurrent + 1);
-            changeStoryGroup(storyGroupCurrent - 1);
-        }
-    }, [storyGroups.length]);
+    // useEffect(() => {
+    //     if (!storyGroups[storyGroupCurrent] && switchToGroupByIdNext === '') {
+    //         if (storyGroups[storyGroupCurrent + 1]) {
+    //             changeStoryGroup(storyGroupCurrent + 1);
+    //         }
+    //         // changeStoryGroup(storyGroupCurrent - 1);
+    //     }
+    // }, [storyGroups.length]);
 
     // By passing an empty array as the second argument to this useEffect
     // We make it so UseEffect is only called once, onMount
@@ -176,7 +178,18 @@ function Stories(props) {
     };
 
     const handleDeleteGroup = (storyGroup) => {
-        if (!storyGroup.introStory) Meteor.call('storyGroups.delete', storyGroup);
+        if (!storyGroup.introStory) {
+            Meteor.call('storyGroups.delete', storyGroup, () => {
+                /* if the story group was the last story group, change the
+                selected index to be the new last story group */
+                const deletedStoryIndex = storyGroups.findIndex(({ _id }) => _id === storyGroup._id);
+                if (storyGroupCurrent > deletedStoryIndex || storyGroupCurrent === storyGroups.length - 1) {
+                    changeStoryGroup(storyGroupCurrent - 1);
+                    return;
+                }
+                changeStoryGroup(storyGroupCurrent);
+            });
+        }
     };
     const handleStoryGroupSelect = storyGroup => Meteor.call('storyGroups.update', {
         ...storyGroup,
@@ -239,6 +252,7 @@ function Stories(props) {
                 templates: [...project.templates],
                 stories,
                 storyGroups,
+                deleteStoryGroup: handleDeleteGroup,
             }}
         >
             {modalWrapper(

--- a/botfront/imports/ui/components/stories/StoryGroupItem.jsx
+++ b/botfront/imports/ui/components/stories/StoryGroupItem.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import {
     Menu, Icon, Input, Loader, Confirm,
 } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import EllipsisMenu from '../common/EllipsisMenu';
+import { ConversationOptionsContext } from '../utils/Context';
 
 function StoryGroupItem(props) {
     const {
@@ -24,6 +25,8 @@ function StoryGroupItem(props) {
     const [editing, setEditing] = useState(false);
     const [storyName, setStoryName] = useState(item[nameAccessor]);
     const [deletable, setDeletable] = useState(false);
+
+    const { deleteStoryGroup } = useContext(ConversationOptionsContext);
 
     useEffect(() => {
         setStoryName(item[nameAccessor]);
@@ -79,7 +82,8 @@ function StoryGroupItem(props) {
     }
 
     function removeStoryGroup() {
-        Meteor.call('storyGroups.delete', item);
+        // Meteor.call('storyGroups.delete', item);
+        deleteStoryGroup(item);
         setDeletionModalVisible(false);
     }
 

--- a/botfront/imports/ui/components/utils/Context.js
+++ b/botfront/imports/ui/components/utils/Context.js
@@ -7,6 +7,7 @@ export const ConversationOptionsContext = React.createContext({
     language: 'en',
     insertResponse: () => {},
     updateResponse: () => {},
+    deleteStoryGroup: () => {},
     getResponse: () => {},
     templates: [],
     storyGroups: [],


### PR DESCRIPTION
<!-- description of what you achieved -->

test: persist state test should fail when the selected story group is not the expected story group
fix: selected story group is not recalled correctly from redux
refactor: story groups are sorted in alphabetical order

If the feature is a refactor, please explain why your way is better
