### PR TITLE
fix: mongo connection failure message

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -49,16 +49,16 @@ config().then(async config => {
                 useFindAndModify: false,
             });
             clearInterval(mongoConnectInterval)
+            app.listen(port, function() {
+                // eslint-disable-next-line no-console
+                return console.log('Server running at http://127.0.0.1:' + port);
+            });
+            app.config = config;
         } catch (error) {
+            // eslint-disable-next-line no-console
             console.log(`Connection to MongoDB server failed. Retrying... (#${retries})`);
         }
     }, 1000)
-
-    app.listen(port, function() {
-        // eslint-disable-next-line no-console
-        return console.log('Server running at http://127.0.0.1:' + port);
-    });
-    app.config = config;
 });
 module.exports = app;
 

--- a/api/app.js
+++ b/api/app.js
@@ -39,19 +39,20 @@ config().then(async config => {
             transports: [new winston.transports.Console()],
         }),
     );
-    for (let i = 1; i < Number.MAX_VALUE; ++i) {
+    let retries = 0;
+    const mongoConnectInterval = setInterval(async () => {
+        retries += 1;
         try {
             await mongoose.connect(config.mongo.host, {
                 keepAlive: true,
                 useNewUrlParser: true,
                 useFindAndModify: false,
             });
-            break;
+            clearInterval(mongoConnectInterval)
         } catch (error) {
-            if (i === 1 || i % 1000 === 0)
-                console.log(`Connection to ${config.mongo.host} failed. Retrying... (#${i})`);
+            console.log(`Connection to MongoDB server failed. Retrying... (#${retries})`);
         }
-    }
+    }, 1000)
 
     app.listen(port, function() {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- description of what you achieved -->

fix: remove host information from the MongoDB connection failure message in the api
refactor: when connection fails, attempt to connect every second. Changed from no retry delay

If the feature is a refactor, please explain why your way is better
