### PR TITLE
refactor: rename metadata tab to behaviour

### DIFF
--- a/botfront/imports/ui/components/templates/templates-list/BotResponseEditor.jsx
+++ b/botfront/imports/ui/components/templates/templates-list/BotResponseEditor.jsx
@@ -248,7 +248,7 @@ const BotResponseEditor = (props) => {
                         <div className='response-editor-topbar-section'>
                             <Menu pointing secondary activeIndex={activeTab}>
                                 <MenuItem onClick={() => { setActiveTab(0); }} active={activeTab === 0} className='response-variations' data-cy='variations-tab'>Variations</MenuItem>
-                                <MenuItem onClick={() => { setActiveTab(1); }} active={activeTab === 1} className='metadata' data-cy='metadata-tab'>Metadata</MenuItem>
+                                <MenuItem onClick={() => { setActiveTab(1); }} active={activeTab === 1} className='metadata' data-cy='metadata-tab'>Behaviour</MenuItem>
                             </Menu>
                         </div>
                         <div className='response-editor-topbar-section' />


### PR DESCRIPTION
<!-- description of what you achieved -->

renamed the metadata tab in the bot response editor to behaviour

If the feature is a refactor, please explain why your way is better
