### PR TITLE
Fix/response name input

### DIFF
--- a/botfront/cypress/integration/bot_responses/bot_response.spec.js
+++ b/botfront/cypress/integration/bot_responses/bot_response.spec.js
@@ -14,6 +14,16 @@ describe('Bot responses', function() {
         cy.logout();
     });
 
+    const addTextResponse = (name, content) => {
+        cy.dataCy('create-response').click();
+        cy.dataCy('add-text-response').click();
+        cy.dataCy('response-name-input').click().find('input').type(name);
+        cy.dataCy('bot-response-input').find('textarea').type(content);
+        cy.get('.dimmer').click({ position: 'topLeft' }); // close the response editor
+        cy.get('.dimmer').should('not.exist');
+        cy.dataCy('template-intent').contains(`utter_${name}`).should('exist');
+    };
+
     it('should create a response using the response editor', function() {
         cy.visit('/project/bf/dialogue/templates');
         cy.dataCy('create-response').click();
@@ -168,7 +178,42 @@ describe('Bot responses', function() {
         cy.dataCy('template-intent').parents('.rt-tr-group').find('.edit.icon').click();
         cy.dataCy('response-name-input').should('have.class', 'disabled');
     });
-    
+    it('should create a response using the response editor', function() {
+        cy.visit('/project/bf/dialogue/templates');
+        addTextResponse('test_A', 'text content A');
+        addTextResponse('test_CA', 'text content CA');
+        addTextResponse('test_B', 'text content B');
+        cy.dataCy('template-intent').should('have.length', 3);
+        cy.get('.-filters').find('input').first().click()
+            .type('A');
+        cy.dataCy('template-intent').contains('utter_test_B').should('not.exist');
+        cy.dataCy('template-intent').contains('utter_test_A').should('exist');
+        cy.dataCy('template-intent').contains('utter_test_CA').should('exist');
+        cy.dataCy('edit-response-0').click({ force: true });
+
+        cy.dataCy('response-name-input').find('input').should('have.value', 'utter_test_A');
+        cy.dataCy('bot-response-input').should('have.text', 'text content A');
+
+        cy.dataCy('response-name-input').click().find('input').clear()
+            .type('utter_test_D')
+            .blur();
+        cy.dataCy('bot-response-input')
+            .find('textarea')
+            .clear()
+            .type('edited content')
+            .blur();
+        cy.get('.dimmer').click({ position: 'topLeft' }); // close the response editor
+        cy.get('.dimmer').should('not.exist');
+        cy.dataCy('template-intent').should('have.length', 1);
+        cy.dataCy('template-intent').contains('utter_test_A').should('not.exist');
+        cy.get('.-filters').find('input').first().click()
+            .clear();
+        cy.dataCy('template-intent').should('have.length', 3);
+        cy.dataCy('template-intent')
+            .contains('utter_test_D')
+            .parents('.rt-tr').find('[data-cy=response-text]')
+            .should('have.text', 'edited content');
+    });
     it('be able to edit a response with the response editor in the visual story editor', function() {
         cy.visit('/project/bf/stories');
         cy.dataCy('add-item').click();

--- a/botfront/cypress/integration/bot_responses/bot_response.spec.js
+++ b/botfront/cypress/integration/bot_responses/bot_response.spec.js
@@ -153,6 +153,7 @@ describe('Bot responses', function() {
         cy.wait(100);
         cy.dataCy('response-name-error').should('exist');
     });
+
     it('should disable response name input if the response is used in a story', function() {
         cy.visit('/project/bf/stories');
         cy.dataCy('add-item').click();
@@ -178,6 +179,7 @@ describe('Bot responses', function() {
         cy.dataCy('template-intent').parents('.rt-tr-group').find('.edit.icon').click();
         cy.dataCy('response-name-input').should('have.class', 'disabled');
     });
+    
     it('should create a response using the response editor', function() {
         cy.visit('/project/bf/dialogue/templates');
         addTextResponse('test_A', 'text content A');

--- a/botfront/imports/ui/components/templates/common/ResponseNameInput.jsx
+++ b/botfront/imports/ui/components/templates/common/ResponseNameInput.jsx
@@ -47,7 +47,7 @@ const ResponseNameInput = (props) => {
 
 ResponseNameInput.propTypes = {
     renameable: PropTypes.bool,
-    onChange:  PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
     saveResponseName: PropTypes.func.isRequired,
     errorMessage: PropTypes.string,
     responseName: PropTypes.string.isRequired,

--- a/botfront/imports/ui/components/templates/templates-list/BotResponseEditor.jsx
+++ b/botfront/imports/ui/components/templates/templates-list/BotResponseEditor.jsx
@@ -51,7 +51,7 @@ const BotResponseEditor = (props) => {
     const [createBotResponse] = useMutation(CREATE_BOT_RESPONSE);
     const [updateBotResponse] = useMutation(UPDATE_BOT_RESPONSE);
     const [deleteVariation] = useMutation(DELETE_VARIATION);
-
+    
     const [newBotResponse, setNewBotResponse] = useState(botResponse);
     const [activeTab, setActiveTab] = useState(0);
     const [responseKey, setResponseKey] = useState(botResponse.key);

--- a/botfront/imports/ui/components/templates/templates-list/BotResponseEditor.jsx
+++ b/botfront/imports/ui/components/templates/templates-list/BotResponseEditor.jsx
@@ -51,7 +51,7 @@ const BotResponseEditor = (props) => {
     const [createBotResponse] = useMutation(CREATE_BOT_RESPONSE);
     const [updateBotResponse] = useMutation(UPDATE_BOT_RESPONSE);
     const [deleteVariation] = useMutation(DELETE_VARIATION);
-    
+
     const [newBotResponse, setNewBotResponse] = useState(botResponse);
     const [activeTab, setActiveTab] = useState(0);
     const [responseKey, setResponseKey] = useState(botResponse.key);
@@ -60,6 +60,7 @@ const BotResponseEditor = (props) => {
 
     useEffect(() => {
         setNewBotResponse(botResponse);
+        setResponseKey(botResponse.key);
     }, [botResponse]);
 
     const validateResponseName = (err) => {

--- a/botfront/imports/ui/components/templates/templates-list/TemplatesTable.jsx
+++ b/botfront/imports/ui/components/templates/templates-list/TemplatesTable.jsx
@@ -51,27 +51,16 @@ class TemplatesTable extends React.Component {
                 accessor: 'key',
                 className: 'center',
                 Cell: ({ value: key, viewIndex: index }) => {
-                    const { templates, activeEditor, setActiveEditor } = this.props;
+                    const { templates, setActiveEditor } = this.props;
                     const botResponse = templates.find(({ key: templateKey }) => templateKey === key) || {};
                     return (
-                        <BotResponseEditor
-                            trigger={(
-                                <Icon
-                                    link
-                                    data-cy={`edit-response-${index}`}
-                                    name='edit'
-                                    color='grey'
-                                    size='small'
-                                    onClick={() => setActiveEditor(botResponse._id)}
-                                />
-                            )}
-                            open={activeEditor === botResponse._id}
-                            botResponse={botResponse || null}
-                            closeModal={() => setActiveEditor('')}
-                            renameable={!events.find((storyEvents) => {
-                                if (!storyEvents) return false;
-                                return storyEvents.find(responseName => responseName === key);
-                            })}
+                        <Icon
+                            link
+                            data-cy={`edit-response-${index}`}
+                            name='edit'
+                            color='grey'
+                            size='small'
+                            onClick={() => setActiveEditor(botResponse._id)}
                         />
                     );
                 },
@@ -224,9 +213,30 @@ class TemplatesTable extends React.Component {
         changeWorkingLanguage(this.getTemplateLanguages(templates)[activeIndex]);
     };
 
+    renderBotResponseEditor() {
+        const {
+            activeEditor, setActiveEditor, events, templates,
+        } = this.props;
+        const botResponse = templates.find(({ _id }) => _id === activeEditor) || {};
+        return (
+            <BotResponseEditor
+                trigger={(
+                    <div />
+                )}
+                open={activeEditor !== null}
+                botResponse={botResponse || null}
+                closeModal={() => setActiveEditor(null)}
+                renameable={!events.find((storyEvents) => {
+                    if (!storyEvents) return false;
+                    return storyEvents.find(responseName => responseName === botResponse.key);
+                })}
+            />
+        );
+    }
+
     render() {
         const {
-            nluLanguages, templates, workingLanguage, newResponse, closeNewResponse,
+            nluLanguages, templates, workingLanguage, newResponse, closeNewResponse, activeEditor,
         } = this.props;
         const activeIndex = this.getTemplateLanguages(templates).indexOf(workingLanguage);
         return (
@@ -253,6 +263,7 @@ class TemplatesTable extends React.Component {
                         isNew
                     />
                 )}
+                {activeEditor && this.renderBotResponseEditor()}
             </div>
         );
     }


### PR DESCRIPTION
<!-- description of what you achieved -->

fix: bot response editor displays the wrong name if opened from the responses page with a filter
fix: changing the name of a bot response while filtering closes the bot response editor
