### PR TITLE
refactor: use the authorization header in the healthcheck

### DIFF
--- a/botfront/imports/startup/server/apollo.js
+++ b/botfront/imports/startup/server/apollo.js
@@ -52,11 +52,12 @@ export const runAppolloServer = () => {
 
     WebApp.connectHandlers.use('/health', (req, res) => {
         const { authorization } = req.headers;
-        axios.get('http://localhost:3000/graphql?query=query%20%7BhealthCheck%7D', {
+        const headersObject = authorization ? {
             headers: {
                 authorization,
             },
-        }).then((response) => {
+        } : {};
+        axios.get('http://localhost:3000/graphql?query=query%20%7BhealthCheck%7D', headersObject).then((response) => {
             // handle success
             if (response.data) {
                 if (response.data && response.data.data && response.data.data.healthCheck) {
@@ -64,7 +65,7 @@ export const runAppolloServer = () => {
                     res.end();
                 }
             } else {
-                res.statusCode = 503;
+                res.statusCode = 401;
                 res.end();
             }
         }).catch(function (error) {

--- a/botfront/imports/startup/server/apollo.js
+++ b/botfront/imports/startup/server/apollo.js
@@ -51,7 +51,12 @@ export const runAppolloServer = () => {
     });
 
     WebApp.connectHandlers.use('/health', (req, res) => {
-        axios.get('http://localhost:3000/graphql?query=query%20%7BhealthCheck%7D').then((response) => {
+        const { authorization } = req.headers;
+        axios.get('http://localhost:3000/graphql?query=query%20%7BhealthCheck%7D', {
+            headers: {
+                authorization,
+            },
+        }).then((response) => {
             // handle success
             if (response.data) {
                 if (response.data && response.data.data && response.data.data.healthCheck) {


### PR DESCRIPTION
transfer the authorization header to the graphQL healthcheck call

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
