### PR TITLE
chore: raise graphql request size limit; expose env param

### DIFF
--- a/botfront/imports/startup/server/apollo.js
+++ b/botfront/imports/startup/server/apollo.js
@@ -42,6 +42,7 @@ export const runAppolloServer = () => {
     server.applyMiddleware({
         app: WebApp.connectHandlers,
         path: '/graphql',
+        bodyParserConfig: { limit: process.env.GRAPHQL_REQUEST_SIZE_LIMIT || '200kb' },
     });
 
     WebApp.connectHandlers.use('/graphql', (req, res) => {


### PR DESCRIPTION
Raises default request limit from 100 to 200kb. Also allows setting it with environment variable GRAPHQL_REQUEST_SIZE_LIMIT.