### PR TITLE
Fix/story search inconsistency

### DIFF
--- a/botfront/cypress/integration/bot_responses/bot_response_consistency.spec.js
+++ b/botfront/cypress/integration/bot_responses/bot_response_consistency.spec.js
@@ -154,4 +154,17 @@ describe('Bot responses', function() {
         cy.dataCy('response-text').contains('third response should exist').should('exist');
         cy.dataCy('template-intent').should('have.length', 2);
     });
+    it('should ignore stories from other projects when deleting responses', () => {
+        cy.visit('/project/bf/stories');
+        cy.browseToStory('Farewells', 'Default stories');
+        cy.dataCy('story-title').should('have.value', 'Farewells');
+        cy.dataCy('bot-response-input').find('textarea').click().type('a')
+            .blur();
+        cy.visit('/project/bf/dialogue/templates');
+        cy.dataCy('template-intent').contains('utter_bye').should('exist');
+        cy.visit('/project/bf/stories');
+        cy.browseToStory('Farewells', 'Default stories');
+        cy.deleteStoryOrGroup('Farewells');
+        checkResponsesDeleted();
+    });
 });

--- a/botfront/imports/api/graphql/botResponses/mongo/botResponses.js
+++ b/botfront/imports/api/graphql/botResponses/mongo/botResponses.js
@@ -220,7 +220,7 @@ export const newGetBotResponses = async ({
 
 
 export const deleteResponsesRemovedFromStories = (removedResponses, projectId) => {
-    const sharedResponses = Stories.find({ events: { $in: removedResponses } }, { fields: { events: true } }).fetch();
+    const sharedResponses = Stories.find({ projectId, events: { $in: removedResponses } }, { fields: { events: true } }).fetch();
     if (removedResponses && removedResponses.length > 0) {
         const deleteResponses = removedResponses.filter((event) => {
             if (!sharedResponses) return true;

--- a/botfront/imports/api/graphql/story/mongo/stories.js
+++ b/botfront/imports/api/graphql/story/mongo/stories.js
@@ -5,8 +5,8 @@ import BotResponses from '../../botResponses/botResponses.model';
 
 const combineSearches = (search, responseKeys, intents) => {
     const searchRegex = [search];
-    if (responseKeys.length) searchRegex.push(responseKeys);
-    if (intents.length) searchRegex.push(intents);
+    if (responseKeys.length) searchRegex.push(responseKeys.join('|'));
+    if (intents.length) searchRegex.push(intents.join('|'));
     return searchRegex.join('|');
 };
 

--- a/botfront/imports/api/graphql/story/unit_tests/indexTestData.js
+++ b/botfront/imports/api/graphql/story/unit_tests/indexTestData.js
@@ -13,20 +13,6 @@ export const storyFixture = {
     branches: [],
 };
 
-// morning
-// matin
-// timeOfDay
-// 123
-// button_intent
-// buttonEntity
-// second
-// http://google.com
-// Canada
-// country
-// test_slot
-// action_testAction
-
-
 export const frModelFixture = {
     _id: frModelId,
     name: 'My First Model',
@@ -112,6 +98,21 @@ export const enModelFixture = {
                     {
                         start: 24,
                         end: 31,
+                        value: 'morning',
+                        entity: 'timeOfDay',
+                    },
+                ],
+                updatedAt: { $date: { $numberLong: '1583766541865' } },
+            },
+            { // to test that multiple intent matches do not break the search regexp
+                _id: '055ba31b-b7ad-4ad4-8fd4-10fecccda971',
+                text: 'How can you help me out this morning?',
+                intent: 'get_started',
+                canonical: true,
+                entities: [
+                    {
+                        start: 28,
+                        end: 35,
                         value: 'morning',
                         entity: 'timeOfDay',
                     },
@@ -218,6 +219,12 @@ export const botResponsesFixture = [
     {
         _id: '5e6805edc1198ff7c7a93cdf',
         key: 'utter_TEST',
+        values: [{ lang: 'en', sequence: [{ content: 'text: test 123\n' }] }],
+        projectId: 'bf',
+    },
+    { // to test that multiple response matches do not break the search regexp
+        _id: '5e6805edc1198ff7c7a93cdg',
+        key: 'utter_TEST_B',
         values: [{ lang: 'en', sequence: [{ content: 'text: test 123\n' }] }],
         projectId: 'bf',
     },

--- a/botfront/imports/api/graphql/story/unit_tests/storySearch.test.js
+++ b/botfront/imports/api/graphql/story/unit_tests/storySearch.test.js
@@ -69,7 +69,7 @@ if (Meteor.isServer) {
         }
     };
     // ------ test suite -------
-    describe('test searching stories by their index', () => {
+    describe.only('test searching stories by their index', () => {
         before((done) => {
             insertDataAndIndex(done);
         });

--- a/botfront/imports/api/graphql/story/unit_tests/storySearch.test.js
+++ b/botfront/imports/api/graphql/story/unit_tests/storySearch.test.js
@@ -69,7 +69,7 @@ if (Meteor.isServer) {
         }
     };
     // ------ test suite -------
-    describe.only('test searching stories by their index', () => {
+    describe('test searching stories by their index', () => {
         before((done) => {
             insertDataAndIndex(done);
         });

--- a/botfront/imports/api/story/stories.methods.js
+++ b/botfront/imports/api/story/stories.methods.js
@@ -58,7 +58,7 @@ Meteor.methods({
                 {
                     $set: {
                         ...rest,
-                        ...indexStory(originStories.find(({ sid }) => sid === _id) || {}, { includeEventsField: true, update: { ...rest, _id } }),
+                        ...indexStory(originStories.find(({ _id: sid }) => sid === _id) || {}, { includeEventsField: true, update: { ...rest, _id } }),
                     },
                 },
             ));

--- a/botfront/imports/api/story/storyMethods.test.js
+++ b/botfront/imports/api/story/storyMethods.test.js
@@ -1,0 +1,148 @@
+
+import { expect } from 'chai';
+import { Meteor } from 'meteor/meteor';
+import { Stories } from './stories.collection';
+
+if (Meteor.isServer) {
+    import './stories.methods';
+
+    const storyIds = ['story_A', 'story_B'];
+    const storyFixtureA = {
+        _id: storyIds[0],
+        title: 'Welcome Story',
+        storyGroupId: 'pYAvAsYw256uy8bGF',
+        projectId: 'bf',
+        events: [
+            'utter_hello',
+            'utter_tXd-Pm66',
+            'utter_Xywmv8uc',
+            'utter_hwZIDQ5P',
+            'utter_0H5XEC9h',
+            'action_help',
+        ],
+        branches: [
+            {
+                title: 'New Branch 1',
+                branches: [],
+                _id: 'story_A_branch_A',
+                story: '* helpOptions\n  - action_help\n  - utter_tXd-Pm66',
+            },
+            {
+                title: 'New Branch 2',
+                branches: [],
+                _id: 'story_A_branch_B',
+                story:
+                    '* how_are_you\n  - utter_Xywmv8uc\n* mood{"positive": "good"}\n  - utter_hwZIDQ5P\n  - utter_0H5XEC9h\n  - slot{"mood":"set"}',
+            },
+        ],
+        story: '* hello\n - utter_hello',
+    };
+    const storyFixtureB = {
+        _id: storyIds[1],
+        title: 'Welcome Story',
+        storyGroupId: 'pYAvAsYw256uy8bGF',
+        projectId: 'bf',
+        events: [
+            'utter_hello',
+            'utter_tXd-Pm66',
+            'utter_Xywmv8uc',
+            'utter_hwZIDQ5P',
+            'utter_0H5XEC9h',
+            'action_help',
+        ],
+        branches: [
+            {
+                title: 'New Branch 1',
+                branches: [],
+                _id: 'story_B_branch_A',
+                story: '* helpOptions\n  - action_help\n  - utter_tXd-Pm66',
+            },
+            {
+                title: 'New Branch 2',
+                branches: [],
+                _id: 'story_B_branch_B',
+                story:
+                    '* how_are_you\n  - utter_Xywmv8uc\n* mood{"positive": "good"}\n  - utter_hwZIDQ5P\n  - utter_0H5XEC9h\n  - slot{"mood":"set"}',
+            },
+        ],
+        story: '* hello\n - utter_hello',
+    };
+    
+    // ------ test suite -------
+    describe('story textIndexes and events are kept for all types of updates', () => {
+        beforeEach(done => (async () => {
+            await Stories.remove({ _id: { $in: storyIds } });
+            await Stories.insert(storyFixtureA);
+            await Stories.insert(storyFixtureB);
+            done();
+        })());
+        after(done => (async () => {
+            await Stories.remove();
+            done();
+        })());
+        it('update an array of stories with matching ids', done => (async () => {
+            try {
+                await Meteor.callWithPromise('stories.update', [
+                    { _id: storyIds[0], projectId: 'bf' },
+                    { _id: storyIds[1], projectId: 'bf' },
+                ]);
+                const result = await Stories.find({ _id: { $in: storyIds } }).fetch();
+                expect(result).to.have.length(2);
+                expect(result[0].events).to.have.length(storyFixtureA.events.length);
+                expect(result[0].textIndex).to.deep.equal({
+                    contents: 'hello \n helpOptions \n how_are_you \n mood positive \n utter_hello \n utter_tXd-Pm66 \n utter_Xywmv8uc \n utter_hwZIDQ5P \n utter_0H5XEC9h \n action_help \n mood',
+                    info: 'Welcome Story',
+                });
+                expect(result[1].events).to.have.length(storyFixtureB.events.length);
+                expect(result[1].textIndex).to.deep.equal({
+                    contents: 'hello \n helpOptions \n how_are_you \n mood positive \n utter_hello \n utter_tXd-Pm66 \n utter_Xywmv8uc \n utter_hwZIDQ5P \n utter_0H5XEC9h \n action_help \n mood',
+                    info: 'Welcome Story',
+                });
+                done();
+            } catch (error) {
+                done(error);
+            }
+        })());
+        it('throw an error when projectIds', done => (async () => {
+            await Meteor.call('stories.update', [
+                { _id: storyIds[0], projectId: 'bf' },
+                { _id: storyIds[1], projectId: 'non_matching_id' },
+            ], (error) => {
+                expect(error).to.not.equal(undefined);
+                done();
+            });
+        })());
+        it('update a single story without a branch path', done => (async () => {
+            try {
+                await Meteor.callWithPromise('stories.update', {
+                    _id: storyIds[0], projectId: 'bf',
+                });
+                const result = await Stories.findOne({ _id: storyIds[0] });
+                expect(result.events).to.have.length(storyFixtureA.events.length);
+                expect(result.textIndex).to.deep.equal({
+                    contents: 'hello \n helpOptions \n how_are_you \n mood positive \n utter_hello \n utter_tXd-Pm66 \n utter_Xywmv8uc \n utter_hwZIDQ5P \n utter_0H5XEC9h \n action_help \n mood',
+                    info: 'Welcome Story',
+                });
+                done();
+            } catch (error) {
+                done(error);
+            }
+        })());
+        it('update a single story without a branch path', done => (async () => {
+            try {
+                await Meteor.callWithPromise('stories.update', {
+                    _id: storyIds[0], projectId: 'bf', path: ['story_A', 'story_A_branch_A'],
+                });
+                const result = await Stories.findOne({ _id: storyIds[0] });
+                expect(result.events).to.have.length(storyFixtureA.events.length);
+                expect(result.textIndex).to.deep.equal({
+                    contents: 'hello \n helpOptions \n how_are_you \n mood positive \n utter_hello \n utter_tXd-Pm66 \n utter_Xywmv8uc \n utter_hwZIDQ5P \n utter_0H5XEC9h \n action_help \n mood',
+                    info: 'Welcome Story',
+                });
+                done();
+            } catch (error) {
+                done(error);
+            }
+        })());
+    });
+}

--- a/botfront/server/migrations.js
+++ b/botfront/server/migrations.js
@@ -243,6 +243,16 @@ Migrations.add({
         });
     },
 });
+Migrations.add({
+    version: 9,
+    up: () => {
+        const allStories = Stories.find().fetch();
+        allStories.forEach((story) => {
+            const { textIndex, events } = indexStory(story, { includeEventsField: true });
+            Stories.update({ _id: story._id }, { $set: { textIndex, events } });
+        });
+    },
+});
 Meteor.startup(() => {
     Migrations.migrateTo('latest');
 });


### PR DESCRIPTION
<!-- description of what you achieved -->


https://app.asana.com/0/1170145499389908/1170249496694281
https://app.asana.com/0/1170145499389908/1169834310671625

the events and text index fields were set to undefined when stories were moved in the story group menu. This caused responses in stories to not be deleted on story delete as well as breaking the stories search.

fix: responses are not deleted when the story is deleted
fix: stories are occasionally not found
test: stories are indexed in all possible branches of 'stories.update'
test: finding multiple matching intents or responses during a story does not break the search