### PR TITLE
refactor: pipeline correction for imported file in training tests

### DIFF
--- a/botfront/cypress/fixtures/branch_link_project.json
+++ b/botfront/cypress/fixtures/branch_link_project.json
@@ -20,7 +20,7 @@
         {
             "_id": "20000a89-85c8-41cb-a706-5d7028cad0cf",
             "language": "en",
-            "config": "pipeline:\n  - name: WhitespaceTokenizer\n  - name: CountVectorsFeaturizer\n  - name: EmbeddingIntentClassifier\n   - name: rasa_addons.nlu.components.gazette.Gazette\n  - name: EntitySynonymMapper",
+            "config": "pipeline:\n  - name: WhitespaceTokenizer\n  - name: CountVectorsFeaturizer\n  - name: DIETClassifier\n  - name: rasa_addons.nlu.components.gazette.Gazette\n  - name: EntitySynonymMapper",
             "evaluations": [],
             "intents": [],
             "chitchat_intents": [],

--- a/botfront/cypress/integration/stories/play_button.spec.js
+++ b/botfront/cypress/integration/stories/play_button.spec.js
@@ -42,7 +42,9 @@ describe('Story play button', function() {
     it('should disable the play button when a story does not start with a user utterance', () => {
         cy.visit('/project/bf/stories');
         cy.browseToStory('Test Story', 'Test Group');
+        cy.get('.story-line').should('have.length', 2);
         cy.dataCy('icon-trash').first().click({ force: true });
+        cy.get('.story-line').should('have.length', 1);
         cy.dataCy('play-story').click();
         cy.dataCy('chat-pane').should('not.exist');
         cy.dataCy('play-story').should('have.class', 'disabled');


### PR DESCRIPTION
The was three spaces instead of two before  
```- name: rasa_addons.nlu.components.gazette.Gazette\n ```
also update the pipeline so it uses the new DIETClassifier
