### PR TITLE
refactor: save edited botresponses when unmounting

### DIFF
--- a/botfront/imports/ui/components/stories/StoryGroupTreeNode.jsx
+++ b/botfront/imports/ui/components/stories/StoryGroupTreeNode.jsx
@@ -135,7 +135,8 @@ const StoryGroupTreeNode = (props) => {
             <Menu.Item
                 active={isInSelection || isHoverTarget}
                 {...(isLeaf ? {
-                    onMouseDown: ({ nativeEvent: { shiftKey } }) => handleMouseDownInMenu({ item, shiftKey }),
+                    // we blur the active element so if something was being type, it's saved
+                    onMouseDown: ({ nativeEvent: { shiftKey } }) => { document.activeElement.blur(); handleMouseDownInMenu({ item, shiftKey }); },
                     onMouseEnter: () => handleMouseEnterInMenu({ item }),
                 } : {})}
             >


### PR DESCRIPTION
prevent lost of input when changing stories without an explicit blur of the bot response

<!-- description of what you achieved -->


- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
