### PR TITLE
fix: missing environement field in the gql schema for trackerstore

### DIFF
--- a/botfront/imports/api/graphql/trackerStore/schemas/trackerStore.types.graphql
+++ b/botfront/imports/api/graphql/trackerStore/schemas/trackerStore.types.graphql
@@ -8,8 +8,8 @@ type Query {
 }
 
 type Mutation {
-    insertTrackerStore(senderId: String!, projectId: String!, tracker: Any): trackerStoreInfo!
-    updateTrackerStore(senderId: String!, projectId: String!, tracker: Any): trackerStoreInfo!
+    insertTrackerStore(senderId: String!, projectId: String!, tracker: Any, env: Environement = development): trackerStoreInfo!
+    updateTrackerStore(senderId: String!, projectId: String!, tracker: Any, env: Environement = development): trackerStoreInfo!
 }
 
 
@@ -17,4 +17,10 @@ type trackerStoreInfo{
     tracker: Any,
     lastIndex: Int,
     lastTimestamp: Float
+}
+
+enum Environement{
+    development
+    production
+    staging
 }


### PR DESCRIPTION
fix https://github.com/botfront/botfront/issues/569