### PR TITLE
refactor: use meteor authtoken to execute graphql query from cypress

### DIFF
--- a/botfront/cypress/plugins/index.js
+++ b/botfront/cypress/plugins/index.js
@@ -12,6 +12,8 @@
 // the project's config changing)
 
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-}
+    // `on` is used to hook into various events Cypress emits
+    // `config` is the resolved Cypress config
+};
+
+module.exports = (on) => { on('task', { log (message) { console.log(message); return null; } }); };


### PR DESCRIPTION
Some cypress tests rely on a POST request to the graphql endpoint. It did not work if you had an API_KEY set up. This actually authenticates the cypress request using the usual mechanism.