### PR TITLE
fix: do not save duckling entities

### DIFF
--- a/botfront/imports/ui/components/utils/EntityUtils.js
+++ b/botfront/imports/ui/components/utils/EntityUtils.js
@@ -55,6 +55,6 @@ export default class EntityUtils {
 
     static filterDuckling(entity) {
         const { extractor = '' } = entity || {};
-        return !extractor.startsWith('duckling') && !extractor.startsWith('ner_duckling');
+        return !extractor.startsWith('duckling') && !extractor.startsWith('ner_duckling') && !extractor.startsWith('DucklingHTTPExtractor');
     }
 }


### PR DESCRIPTION
<!-- description of what you achieved -->
duckling entities should not be saved in nlu data (from the playground)

add the following to the nlu-pipeline settings to enable duckling

>   - name: "DucklingHTTPExtractor"
>     url: "http://host.docker.internal:8000"
>     dimensions:
>       - number
>       - time
>     locale: "en_US"
>     timeout : 3