### PR TITLE
refactor: hide the image not found icon before setting the image

### DIFF
--- a/botfront/imports/ui/components/stories/common/ImageThumbnail.jsx
+++ b/botfront/imports/ui/components/stories/common/ImageThumbnail.jsx
@@ -65,7 +65,7 @@ export default function ImageThumbnail(props) {
                     )}
                 </div>
             </div>
-            <Image src={value || ''} size='small' alt='' />
+            <Image src={value || '/images/image-temp.svg'} size='small' alt='' />
             {modalOpen && (
                 <Modal
                     open

--- a/botfront/imports/ui/components/stories/common/ImageThumbnail.jsx
+++ b/botfront/imports/ui/components/stories/common/ImageThumbnail.jsx
@@ -65,7 +65,7 @@ export default function ImageThumbnail(props) {
                     )}
                 </div>
             </div>
-            <Image src={value || ''} size='small' alt=' ' />
+            <Image src={value || ''} size='small' alt='' />
             {modalOpen && (
                 <Modal
                     open

--- a/botfront/public/images/image-temp.svg
+++ b/botfront/public/images/image-temp.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" focusable="false" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	 x="0px" y="0px" viewBox="0 0 512 364" style="enable-background:new 0 0 512 364;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M323.8,252.3H188.2c-8.6,0-15.6-7-15.6-15.6v-93.8c0-8.6,7-15.6,15.6-15.6h135.5c8.6,0,15.6,7,15.6,15.6v93.8
+	C339.4,245.3,332.4,252.3,323.8,252.3z M209.1,145.4c-10.1,0-18.2,8.2-18.2,18.2s8.2,18.2,18.2,18.2s18.2-8.2,18.2-18.2
+	S219.2,145.4,209.1,145.4z M193.4,231.4h125.1v-36.5L290,166.4c-1.5-1.5-4-1.5-5.5,0l-44.2,44.2l-18.1-18.1c-1.5-1.5-4-1.5-5.5,0
+	l-23.3,23.3V231.4z"/>
+</svg>


### PR DESCRIPTION
hide Image not found icon when creating a image response
- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
