### PR TITLE
refactor: hide copyFrom in the botresponse when there is one language

### DIFF
--- a/botfront/imports/ui/components/stories/common/BotResponsesContainer.jsx
+++ b/botfront/imports/ui/components/stories/common/BotResponsesContainer.jsx
@@ -187,25 +187,25 @@ const BotResponsesContainer = (props) => {
                         onToggleButtonType={handleToggleQuickReply}
                         responseType={typeName}
                     />
-                    {initialValue && !initialValue.isNew && getSequence().length === 1 && !checkContentEmpty(getSequence()[0])
-                         && (
-                             <Dropdown
-                                 button
-                                 icon={null}
-                                 compact
-                                 data-cy='import-from-lang'
-                                 className='import-from-lang'
-                                 options={otherLanguages}
-                                 text='Copy from'
-                                 onChange={(_, selection) => {
-                                     importRespFromLang({
-                                         variables: {
-                                             projectId, key: name, originLang: selection.value, destLang: language,
-                                         },
-                                     });
-                                 }}
-                             />
-                         )
+                    {otherLanguages.length > 0 && initialValue && !initialValue.isNew && getSequence().length === 1 && !checkContentEmpty(getSequence()[0])
+                        && (
+                            <Dropdown
+                                button
+                                icon={null}
+                                compact
+                                data-cy='import-from-lang'
+                                className='import-from-lang'
+                                options={otherLanguages}
+                                text='Copy from'
+                                onChange={(_, selection) => {
+                                    importRespFromLang({
+                                        variables: {
+                                            projectId, key: name, originLang: selection.value, destLang: language,
+                                        },
+                                    });
+                                }}
+                            />
+                        )
                     }
                     {enableEditPopup && (
                         <IconButton

--- a/botfront/imports/ui/layouts/project.jsx
+++ b/botfront/imports/ui/layouts/project.jsx
@@ -375,7 +375,7 @@ class Project extends React.Component {
                                     entities,
                                     slots,
                                     language: workingLanguage,
-                                    otherLanguages: projectLanguages.filter(lang => lang.value !== workingLanguage),
+                                    otherLanguages: projectLanguages ? projectLanguages.filter(lang => lang.value !== workingLanguage) : [],
                                     triggerChatPane: this.triggerChatPane,
                                     upsertResponse: this.upsertResponse,
                                     responses,


### PR DESCRIPTION
hide copyFrom in the botresponse when there is one language

