### PR TITLE
refactor: prevent entities report crash when empty

### DIFF
--- a/botfront/imports/ui/components/nlu/evaluation/EntityReport.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/EntityReport.jsx
@@ -344,7 +344,7 @@ export default class EntityReport extends React.Component {
     }
 
     render = () => {
-        const { accuracy, precision, f1_score: f1 } = this.props;
+        const { accuracy = 0, precision = 0, f1_score: f1 = 0 } = this.props;
         return (
             <div>
                 <br />

--- a/botfront/imports/ui/components/nlu/evaluation/EntityReport.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/EntityReport.jsx
@@ -344,7 +344,7 @@ export default class EntityReport extends React.Component {
     }
 
     render = () => {
-        const { accuracy = 0, precision = 0, f1_score: f1 = 0 } = this.props;
+        const { accuracy, precision, f1_score: f1 } = this.props;
         return (
             <div>
                 <br />

--- a/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/Evaluation.jsx
@@ -71,7 +71,7 @@ class Evaluation extends React.Component {
                 render: () => <IntentReport {...intentEvaluation} />,
             });
         }
-        if (entityEvaluation) {
+        if (entityEvaluation && Object.keys(entityEvaluation).length > 0) {
             menuItems.push({
                 menuItem: 'Entities',
                 render: () => <EntityReport {...entityEvaluation} />,

--- a/botfront/imports/ui/components/nlu/evaluation/ReportTable.jsx
+++ b/botfront/imports/ui/components/nlu/evaluation/ReportTable.jsx
@@ -9,6 +9,7 @@ export default function ReportTable(props) {
 
     const getReportData = () => {
         const { report } = props;
+        if (!report) return [];
         return Object.keys(report).reduce((acc, key) => {
             if (['micro avg', 'macro avg', 'weighted avg', 'accuracy'].includes(key)) return acc;
             return [...acc, { [labelType]: key, ...report[key] }];


### PR DESCRIPTION
when there was no entities in the entity report it was crashing bf, use default value to prevent it