### PR TITLE
refactor: autovalidate incoming utterances when changes are made

### DIFF
--- a/botfront/cypress/integration/incoming/new_utterances.spec.js
+++ b/botfront/cypress/integration/incoming/new_utterances.spec.js
@@ -1,5 +1,4 @@
 /* global cy Cypress:true */
-
 describe('incoming page', function() {
     beforeEach(function() {
         cy.createProject('bf', 'My Project', 'en').then(() => {
@@ -70,5 +69,18 @@ describe('incoming page', function() {
         cy.selectOrUnselectIncomingRow('kiwi');
         cy.deleteSelectedUtterances();
         cy.get('.row').should('have.length', 1).should('contain.text', 'banana');
+    });
+
+    it('should automatically validate the utterance if there is an intent', function() {
+        cy.selectOrUnselectIncomingRow('apple');
+        cy.selectOrUnselectIncomingRow('banana');
+        cy.changeIntentOfSelectedUtterances('fruit');
+        cy.get('.virtual-table').findCy('invalidate-utterance').should('have.length', 2);
+    });
+
+    it('should not automatically validate the utterance  when there is no intent', function() {
+        cy.selectOrUnselectIncomingRow('apple');
+        cy.dataCy('remove-intent').first().click({ force: true });
+        cy.get('.virtual-table').findCy('validate-utterance').should('have.length', 3);
     });
 });

--- a/botfront/cypress/integration/incoming/new_utterances.spec.js
+++ b/botfront/cypress/integration/incoming/new_utterances.spec.js
@@ -63,12 +63,20 @@ describe('incoming page', function() {
         cy.selectOrUnselectIncomingRow('banana');
         cy.dataCy('activity-command-bar').should('exist').should('contain.text', '2 selected');
         cy.changeIntentOfSelectedUtterances('fruit');
-        cy.toggleValidationOfSelectedUtterances();
         cy.get('.virtual-table').findCy('invalidate-utterance').should('have.length', 2);
         cy.selectOrUnselectIncomingRow('banana');
         cy.selectOrUnselectIncomingRow('kiwi');
         cy.deleteSelectedUtterances();
         cy.get('.row').should('have.length', 1).should('contain.text', 'banana');
+    });
+
+    it('should batch validate', function() {
+        cy.selectOrUnselectIncomingRow('apple');
+        cy.dataCy('activity-command-bar').should('not.exist');
+        cy.selectOrUnselectIncomingRow('banana');
+        cy.dataCy('activity-command-bar').should('exist').should('contain.text', '2 selected');
+        cy.toggleValidationOfSelectedUtterances();
+        cy.get('.virtual-table').findCy('invalidate-utterance').should('have.length', 2);
     });
 
     it('should automatically validate the utterance if there is an intent', function() {

--- a/botfront/imports/ui/components/nlu/activity/Activity.jsx
+++ b/botfront/imports/ui/components/nlu/activity/Activity.jsx
@@ -116,16 +116,23 @@ function Activity(props) {
     };
 
     const handleUpdate = async (newData) => {
+        const possiblyValidated = newData.filter(utterance => utterance.validated !== false).map(utterance => utterance._id);
         const dataUpdated = clearTypenameField(
             data
                 .filter(d1 => newData.map(d2 => d2._id).includes(d1._id))
                 .map(d1 => ({ ...d1, ...newData.find(d2 => d2._id === d1._id) })),
         );
+        
+        const toInsert = dataUpdated.map((utterance) => {
+            if (possiblyValidated.includes(utterance._id) && utterance.intent && utterance.validated !== undefined) return { ...utterance, validated: true };
+            return utterance;
+        });
+       
         return upsertActivity({
-            variables: { data: dataUpdated },
+            variables: { data: toInsert },
             optimisticResponse: {
                 __typename: 'Mutation',
-                upsertActivity: dataUpdated.map(d => ({
+                upsertActivity: toInsert.map(d => ({
                     __typename: 'Activity',
                     ...d,
                 })),

--- a/botfront/imports/ui/components/nlu/common/IntentLabel.jsx
+++ b/botfront/imports/ui/components/nlu/common/IntentLabel.jsx
@@ -231,6 +231,7 @@ const Intent = React.forwardRef((props, ref) => {
             {showReset && (
                 <Icon
                     name='x'
+                    data-cy='remove-intent'
                     className='action-on-label'
                     onClick={() => handleChange('')}
                 />


### PR DESCRIPTION
autovalidate incoming utterances when changes are made
only happen if there is an intent set

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed
