### PR TITLE
fix: new chitchat examples were not displayed in the examples table

### DIFF
--- a/botfront/imports/ui/components/nlu/models/NLUModel.jsx
+++ b/botfront/imports/ui/components/nlu/models/NLUModel.jsx
@@ -207,6 +207,9 @@ function NLUModel(props) {
                 {activeItem === 'Training Data' && (
                     <Tab
                         menu={{ pointing: true, secondary: true }}
+                        // activeIndex === 0 is the example tab, we want to refetch data everytime we land on it
+                        // as it may have changed from the chitchat tab
+                        onTabChange={(e, { activeIndex }) => { if (activeIndex === 0) refetch(); }}
                         panes={[
                             {
                                 menuItem: 'Examples',


### PR DESCRIPTION
after adding chitchat examples the nlu data table was not updated with the newly added examples

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
