### PR TITLE
fix: endpoints saving when the document does not exist

### DIFF
--- a/botfront/imports/api/endpoints/endpoints.methods.js
+++ b/botfront/imports/api/endpoints/endpoints.methods.js
@@ -18,7 +18,7 @@ export const saveEndpoints = async (endpoints) => {
         if (!Meteor.isServer) throw Meteor.Error(400, 'Not Authorized');
         return Endpoints.upsert(
             { projectId: endpoints.projectId },
-            { $set: { endpoints: endpoints.endpoints } },
+            { $set: { endpoints: endpoints.endpoints, projectId: endpoints.projectId, environment: endpoints.environment || 'development' } },
         );
     } catch (e) {
         throw formatError(e);


### PR DESCRIPTION
fix endpoints saving when the document does not exist

