### PR TITLE
style: only show entity names on hover

### DIFF
--- a/botfront/imports/ui/components/nlu/common/EntityLabel.jsx
+++ b/botfront/imports/ui/components/nlu/common/EntityLabel.jsx
@@ -144,7 +144,7 @@ function Entity({
                     data-cy='entity-label'
                     className={`entity-container ${colorToRender}`}
                 >
-                    <span className='float'>
+                    <span className='float entity-name'>
                         {(value.group || value.role || value.text !== value.value) && <>&#9733;</>}
                         {value.entity}
                     </span>

--- a/botfront/imports/ui/components/nlu/common/style.import.less
+++ b/botfront/imports/ui/components/nlu/common/style.import.less
@@ -169,10 +169,25 @@
     position: relative;
     .float {
         position: absolute;
-        width: 100px;
-        bottom: ~"calc(100% - 1px)";
+        max-width: 200px;
+        bottom: ~"calc(100% - 5px)";
         font-size: small;
         user-select: none;
+        border-radius: 4px;
+        padding: 0px 2px 1px 2px;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        z-index: 10;
+    }
+    .entity-name {
+        visibility: hidden;
+    }
+    &:hover {
+        .entity-name {
+            background-color: rgba(252, 252, 252, 0.863);
+            visibility: visible;
+        }
     }
 }
 


### PR DESCRIPTION
- entity names should only appear on hover
- entity names need a background to improve readability

