### PR TITLE
refactor: specific error screen on failed to fetch

### DIFF
--- a/botfront/imports/ui/components/ErrorCatcher.jsx
+++ b/botfront/imports/ui/components/ErrorCatcher.jsx
@@ -12,10 +12,15 @@ export default class ErrorBoundary extends React.Component {
 
     isRootUrlError = () => {
         const { error } = this.state;
+        const possibleErrorMessages = [
+            'Could not connect to the server.',
+            'NetworkError when attempting to fetch resource.',
+            'Failed to fetch',
+        ];
         // eslint-disable-next-line no-undef
         const rootUrlRegex = new RegExp(__meteor_runtime_config__.ROOT_URL);
         return (
-            (error && error[0] && error[0].message === 'Failed to fetch' && error[0].stack === 'TypeError: Failed to fetch')
+            (error && error[0] && possibleErrorMessages.includes(error[0].message))
             && !rootUrlRegex.test(window.location.href)
         );
     }

--- a/botfront/imports/ui/components/ErrorCatcher.jsx
+++ b/botfront/imports/ui/components/ErrorCatcher.jsx
@@ -10,6 +10,16 @@ export default class ErrorBoundary extends React.Component {
         this.state = { error: null, reported: false };
     }
 
+    isRootUrlError = () => {
+        const { error } = this.state;
+        // eslint-disable-next-line no-undef
+        const rootUrlRegex = new RegExp(__meteor_runtime_config__.ROOT_URL);
+        return (
+            (error && error[0] && error[0].message === 'Failed to fetch' && error[0].stack === 'TypeError: Failed to fetch')
+            && !rootUrlRegex.test(window.location.href)
+        );
+    }
+
     componentDidCatch(...error) {
         this.setState({ error });
     }
@@ -19,7 +29,7 @@ export default class ErrorBoundary extends React.Component {
         const {
             children: { props: { location: { pathname = '' } = {} } = {} } = {},
         } = this.props;
-        if (error && error[0] && error[0].message === 'Failed to fetch') {
+        if (this.isRootUrlError()) {
             /*
                 Users commonly forget to setup the ROOT_URL environment variable which
                 throws the "Failed to fetch" error.

--- a/botfront/imports/ui/components/ErrorCatcher.jsx
+++ b/botfront/imports/ui/components/ErrorCatcher.jsx
@@ -48,9 +48,16 @@ export default class ErrorBoundary extends React.Component {
                         >
                             Please configure the ROOT_URL environment variable
                             <Header.Subheader style={{ marginTop: '10px' }}>
-                            The ROOT_URL environment variable must be set to the public URL where your instance of Botfront can be reached
+                                The ROOT_URL environment variable must be set to
+                                the public URL where your instance of Botfront can be reached.
                             </Header.Subheader>
                         </Header>
+                        <p>
+                            For more information visit the{' '}
+                            <a href='https://botfront.io/docs/installation/server-cluster#environment-variables'>
+                                documentation
+                            </a>
+                        </p>
                     </div>
                 </Container>
             );

--- a/botfront/imports/ui/components/ErrorCatcher.jsx
+++ b/botfront/imports/ui/components/ErrorCatcher.jsx
@@ -19,6 +19,32 @@ export default class ErrorBoundary extends React.Component {
         const {
             children: { props: { location: { pathname = '' } = {} } = {} } = {},
         } = this.props;
+        if (error && error[0] && error[0].message === 'Failed to fetch') {
+            /*
+                Users commonly forget to setup the ROOT_URL environment variable which
+                throws the "Failed to fetch" error.
+                To assist users during setup and prevent unnecessary error reports provide
+                the user with a infomative error screen.
+            */
+            return (
+                <Container style={{
+                    height: '100%', display: 'flex', alignItems: 'center',
+                }}
+                >
+                    <div>
+                        <Header
+                            as='h1'
+                            style={{ fontFamily: 'Hind, sans-serif', fontSize: '40px' }}
+                        >
+                            Please configure the ROOT_URL environment variable
+                            <Header.Subheader style={{ marginTop: '10px' }}>
+                            The ROOT_URL environment variable must be set to the public URL where your instance of Botfront can be reached
+                            </Header.Subheader>
+                        </Header>
+                    </div>
+                </Container>
+            );
+        }
         return (
             <Container style={{ height: '100%', display: 'flex', alignItems: 'center' }}>
                 <div>

--- a/botfront/imports/ui/components/ErrorCatcher.jsx
+++ b/botfront/imports/ui/components/ErrorCatcher.jsx
@@ -11,18 +11,9 @@ export default class ErrorBoundary extends React.Component {
     }
 
     isRootUrlError = () => {
-        const { error } = this.state;
-        const possibleErrorMessages = [
-            'Could not connect to the server.',
-            'NetworkError when attempting to fetch resource.',
-            'Failed to fetch',
-        ];
         // eslint-disable-next-line no-undef
         const rootUrlRegex = new RegExp(__meteor_runtime_config__.ROOT_URL);
-        return (
-            (error && error[0] && possibleErrorMessages.includes(error[0].message))
-            && !rootUrlRegex.test(window.location.href)
-        );
+        return !rootUrlRegex.test(window.location.href);
     }
 
     componentDidCatch(...error) {

--- a/botfront/imports/ui/components/utils/CrashReportButton.jsx
+++ b/botfront/imports/ui/components/utils/CrashReportButton.jsx
@@ -49,7 +49,7 @@ const CrashReportButton = (props) => {
     */
     const generateReport = (text = true) => {
         const [err, info] = error;
-        const firstTwoLinesOfStack = err.stack.split('\n').slice(0, 2).join('\n    in ');
+        const firstTwoLinesOfStack = err.stack ? err.stack.split('\n').slice(0, 2).join('\n    in ') : 'stack not available';
         if (text) {
             return (
                 `Version: ${version}\n`


### PR DESCRIPTION
<!-- description of what you achieved -->
incorrect setup for the Root url environment variable triggers a "failed to fetch" error, when this error occurs, provide a case specific error message.
