### PR TITLE
chore: strict clean up of response payload before inserting in domain

### DIFF
--- a/botfront/imports/api/graphql/botResponses/mongo/botResponses.js
+++ b/botfront/imports/api/graphql/botResponses/mongo/botResponses.js
@@ -2,7 +2,7 @@ import { safeDump } from 'js-yaml/lib/js-yaml';
 import shortid from 'shortid';
 import { safeLoad } from 'js-yaml';
 import BotResponses from '../botResponses.model';
-import { clearTypenameField } from '../../../../lib/client.safe.utils';
+import { cleanPayload } from '../../../../lib/client.safe.utils';
 import { Stories } from '../../../story/stories.collection';
 import { addTemplateLanguage, modifyResponseType } from '../../../../lib/botResponse.utils';
 import { parsePayload } from '../../../../lib/storyMd.utils';
@@ -53,9 +53,9 @@ const mergeAndIndexBotResponse = async ({
     }
     const valueIndex = botResponse.values.findIndex(({ lang }) => lang === language);
     if (valueIndex > -1) { // add to existing language
-        botResponse.values[valueIndex].sequence[index] = { content: safeDump(clearTypenameField(newPayload)) };
+        botResponse.values[valueIndex].sequence[index] = { content: safeDump(cleanPayload(newPayload)) };
     } else { // add a new language
-        botResponse.values = [...botResponse.values, { lang: language, sequence: [{ content: safeDump(clearTypenameField(newPayload)) }] }];
+        botResponse.values = [...botResponse.values, { lang: language, sequence: [{ content: safeDump(cleanPayload(newPayload)) }] }];
     }
     return indexBotResponse(botResponse);
 };
@@ -174,12 +174,12 @@ export const upsertResponse = async ({
         ? {
             $push: {
                 'values.$.sequence': {
-                    $each: [{ content: safeDump(clearTypenameField(newPayload)) }],
+                    $each: [{ content: safeDump(cleanPayload(newPayload)) }],
                 },
             },
             $set: { textIndex, ...(newKey ? { key: newKey } : {}) },
         }
-        : { $set: { [`values.$.sequence.${index}`]: { content: safeDump(clearTypenameField(newPayload)) }, textIndex, ...(newKey ? { key: newKey } : {}) } };
+        : { $set: { [`values.$.sequence.${index}`]: { content: safeDump(cleanPayload(newPayload)) }, textIndex, ...(newKey ? { key: newKey } : {}) } };
     const updatedResponse = await BotResponses.findOneAndUpdate(
         { projectId, key, 'values.lang': language },
         update,
@@ -189,7 +189,7 @@ export const upsertResponse = async ({
     || BotResponses.findOneAndUpdate(
         { projectId, key },
         {
-            $push: { values: { lang: language, sequence: [{ content: safeDump(clearTypenameField(newPayload)) }] } },
+            $push: { values: { lang: language, sequence: [{ content: safeDump(cleanPayload(newPayload)) }] } },
             $setOnInsert: {
                 _id: shortid.generate(),
                 projectId,

--- a/botfront/imports/api/graphql/botResponses/resolvers/nlgResolver.js
+++ b/botfront/imports/api/graphql/botResponses/resolvers/nlgResolver.js
@@ -82,7 +82,6 @@ export default {
         image: ({ image }) => image,
     },
     CarouselPayload: {
-        template_type: ({ template_type: templateType }) => templateType,
         text: ({ text }) => text,
         elements: ({ elements }) => elements,
     },

--- a/botfront/imports/api/graphql/botResponses/schemas/botResponses.types.graphql
+++ b/botfront/imports/api/graphql/botResponses/schemas/botResponses.types.graphql
@@ -138,7 +138,7 @@ type ImagePayload implements BotResponsePayload {
 type CarouselPayload implements BotResponsePayload {
     key: String
     text: String
-    template_type: TemplateType!
+    template_type: TemplateType # we don't touch this one for now, as Rasa still tries to access it
     elements: [CarouselElement!]
     metadata: Any
 }

--- a/botfront/imports/lib/botResponse.utils.js
+++ b/botfront/imports/lib/botResponse.utils.js
@@ -88,7 +88,6 @@ export const defaultTemplate = (template) => {
         };
     case 'CarouselPayload':
         return {
-            template_type: 'generic',
             elements: [defaultCarouselSlide()],
             __typename: 'CarouselPayload',
         };
@@ -130,7 +129,6 @@ export const parseContentType = (content) => {
         (content.quick_replies === undefined || Array.isArray(content.quick_replies)),
         (content.elements === undefined || (
             Array.isArray(content.elements)
-            && typeof content.template_type === 'string'
             && content.elements.every(el => (
                 typeof el === 'object'
                 && (el.buttons === undefined || Array.isArray(el.buttons))

--- a/botfront/imports/lib/client.safe.utils.js
+++ b/botfront/imports/lib/client.safe.utils.js
@@ -4,6 +4,25 @@ export function clearTypenameField(object) {
     return cleanedObject;
 }
 
+export const cleanPayload = (payload) => {
+    const clean = clearTypenameField(payload);
+    Object.keys(payload).forEach((k) => {
+        if (
+            ![
+                'text',
+                'metadata',
+                'quick_replies',
+                'buttons',
+                'image',
+                'elements',
+                'attachment',
+                'custom',
+            ].includes(k)
+        ) { delete clean[k]; }
+    });
+    return clean;
+};
+
 export const formNameIsValid = name => name.match(/^[a-zA-Z0-9-_]+_form$/) && name.split('form').length === 2;
 
 export const dropNullValuesFromObject = obj => Object.entries(obj).reduce(

--- a/botfront/imports/lib/story.utils.js
+++ b/botfront/imports/lib/story.utils.js
@@ -4,6 +4,7 @@ import { Stories } from '../api/story/stories.collection';
 import { Projects } from '../api/project/project.collection';
 import { Slots } from '../api/slots/slots.collection';
 import { StoryGroups } from '../api/storyGroups/storyGroups.collection';
+import { cleanPayload } from './client.safe.utils';
 import { newGetBotResponses } from '../api/graphql/botResponses/mongo/botResponses';
 
 let storyAppLogger;
@@ -309,7 +310,8 @@ export const getAllResponses = async (projectId, language = '') => {
     const responses = await newGetBotResponses({ projectId, language });
     return responses.reduce((acc, curr) => {
         const { key, payload, ...rest } = curr;
-        const content = { ...yaml.safeLoad(payload), ...rest };
+        // we do this at the source too, but to be safe here too
+        const content = { ...cleanPayload(yaml.safeLoad(payload)), ...rest };
         if (!(key in acc)) return { ...acc, [key]: [content] };
         return { ...acc, [key]: [...acc[key], content] };
     }, {});

--- a/botfront/imports/ui/layouts/graphql.js
+++ b/botfront/imports/ui/layouts/graphql.js
@@ -15,7 +15,7 @@ const botResponseFields = gql`
         ...on QuickRepliesPayload { text, quick_replies { title, type, ...on WebUrlButton { url }, ...on PostbackButton { payload } } }
         ...on TextWithButtonsPayload { text, buttons { title, type, ...on WebUrlButton { url }, ...on PostbackButton { payload } } }
         ...on ImagePayload { text, image }
-        ...on CarouselPayload { template_type, elements { ...CarouselElementFields } }
+        ...on CarouselPayload { elements { ...CarouselElementFields } }
         ...on CustomPayload { customText: text, customImage: image, customButtons: buttons, customElements: elements, custom, customAttachment: attachment }
     }
 `;


### PR DESCRIPTION
This also phases out `template_type`, which no known Rasa channel uses.