### PR TITLE
Refactor/set slot to null

### DIFF
--- a/botfront/cypress/integration/forms/form_settings_interface.spec.js
+++ b/botfront/cypress/integration/forms/form_settings_interface.spec.js
@@ -162,6 +162,8 @@ describe('use the main form editor interface to', () => {
         cy.wait(300);
         cy.createFragmentInGroup({ type: 'form' });
         cy.meteorAddSlot('bool_slot', 'bool');
+        cy.meteorAddSlot('text_slot', 'text');
+        cy.meteorAddSlot('float_slot', 'float');
         cy.selectForm(newFormName);
 
         cy.dataCy('start-node').click();
@@ -171,14 +173,24 @@ describe('use the main form editor interface to', () => {
 
         cy.dataCy('add-node-1').click();
         cy.dataCy('add-node-1').find('[data-cy=set-slot]').click();
+        cy.get('.item.dropdown').should('not.include.text', 'float')
+        cy.get('.item.dropdown').should('not.include.text', 'text')
+        cy.get('.item.dropdown').should('include.text', 'categorical')
         cy.get('.item.dropdown').contains('bool').click();
         cy.get('.item.dropdown').contains('bool_slot').click();
         cy.get('.item.dropdown').contains('true').click();
         cy.get('.label-container.orange').should('contain.text', 'true').click();
+        cy.get('.item.dropdown').should('not.include.text', 'float')
+        cy.get('.item.dropdown').should('not.include.text', 'text')
+        cy.get('.item.dropdown').should('include.text', 'categorical')
         cy.get('.item.dropdown').contains('bool').click();
         cy.get('.item.dropdown').contains('bool_slot').click();
         cy.get('.item.dropdown').contains('false').click();
         cy.get('.label-container.orange').should('contain.text', 'false').click();
+        cy.get('.item.dropdown').contains('bool').click();
+        cy.get('.item.dropdown').contains('bool_slot').click();
+        cy.get('.item.dropdown').contains('null').click();
+        cy.get('.label-container.orange').should('contain.text', 'null').click();
         cy.dataCy('slot-set-node').find('[data-cy=icon-trash]').click();
         cy.dataCy('slot-set-node').should('not.exist');
     });

--- a/botfront/cypress/integration/forms/form_settings_interface.spec.js
+++ b/botfront/cypress/integration/forms/form_settings_interface.spec.js
@@ -224,7 +224,7 @@ describe('use the main form editor interface to', () => {
         cy.import('bf', 'nlu_entity_sample.json', 'en');
         cy.meteorAddSlot('catSlot', 'categorical');
         cy.createForm('bf', 'test1_form', {
-            slots: [catSlot],
+            slots: [],
         });
         cy.createStoryGroup();
         cy.createFragmentInGroup({ type: 'form' });

--- a/botfront/imports/ui/components/forms/graph/SlotChoiceModal.jsx
+++ b/botfront/imports/ui/components/forms/graph/SlotChoiceModal.jsx
@@ -125,7 +125,7 @@ const SlotChoiceModal = (props) => {
                 onSelect={slot => chooseAddQuestion(slot)}
                 chooseSlotWithoutValue
                 slotsToRemove={slotsUsed}
-                excludeSlotsOfType={['unfeaturized']}
+                excludeSlotsOfType={[]}
             />
         </div>
     );

--- a/botfront/imports/ui/components/forms/graph/SlotChoiceModal.jsx
+++ b/botfront/imports/ui/components/forms/graph/SlotChoiceModal.jsx
@@ -173,6 +173,7 @@ const SlotChoiceModal = (props) => {
                 'float',
                 'list',
                 'unfeaturized',
+                'any',
             ]}
         />
     );

--- a/botfront/imports/ui/components/forms/graph/SlotSetNode.jsx
+++ b/botfront/imports/ui/components/forms/graph/SlotSetNode.jsx
@@ -24,6 +24,13 @@ const SlotSetNode = (props) => {
                 <SlotLabel
                     value={{ [slotName]: slotValue }}
                     onChange={onChangeSlot}
+                    excludeSlotsOfType={[
+                        'text',
+                        'float',
+                        'list',
+                        'unfeaturized',
+                        'any',
+                    ]}
                 />
                 <IconButton
                     icon='trash'

--- a/botfront/imports/ui/components/stories/SlotLabel.jsx
+++ b/botfront/imports/ui/components/stories/SlotLabel.jsx
@@ -10,7 +10,7 @@ export const slotValueToLabel = value => (
             : value.toString()
 );
 
-export default function SlotLabel({ value, onChange, disableSelection }) {
+export default function SlotLabel({ value, onChange, disableSelection, excludeSlotsOfType }) {
     const [name] = Object.keys(value);
     const slotValue = value[name];
 
@@ -30,7 +30,7 @@ export default function SlotLabel({ value, onChange, disableSelection }) {
             onSelect={slot => onChange(slot)}
             value={value}
             disabled={disableSelection}
-            excludeSlotsOfType={['unfeaturized']}
+            excludeSlotsOfType={excludeSlotsOfType}
         />
     );
 }
@@ -39,8 +39,10 @@ SlotLabel.propTypes = {
     value: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     disableSelection: PropTypes.bool,
+    excludeSlotsOfType: PropTypes.array,
 };
 
 SlotLabel.defaultProps = {
     disableSelection: false,
+    excludeSlotsOfType: ['unfeaturized'],
 };

--- a/botfront/imports/ui/components/stories/common/SlotPopupContent.jsx
+++ b/botfront/imports/ui/components/stories/common/SlotPopupContent.jsx
@@ -48,7 +48,7 @@ const SlotPopupContent = (props) => {
 
     function getSlotValue(slot) {
         const { type } = slot;
-        if (type === 'bool') return [true, false];
+        if (type === 'bool') return [true, false, null];
         if (type === 'text') return ['set', null];
         if (type === 'float') return [1.0, null];
         if (type === 'list') return [['not-empty'], []];


### PR DESCRIPTION
<!-- description of what you achieved -->

https://dialoguemd.atlassian.net/browse/DIA-26495?atlOrigin=eyJpIjoiYWUwZjYyZmNhNjZhNDlmOWJjY2IyOWU2NzUwM2QzZmIiLCJwIjoiaiJ9

https://dialoguemd.atlassian.net/browse/DIA-26173?atlOrigin=eyJpIjoiZmJkNjRmZWIzYzM3NDFmZWIyYTg2YTY1ZDg3MGY0ZDkiLCJwIjoiaiJ9

add option for bool and cat slots to be null

fix bug where non-eligible slot types could be set in the slot-set form node