### PR TITLE
feat(default domain): support session_config key in default domain.

### DIFF
--- a/botfront/imports/lib/story.utils.js
+++ b/botfront/imports/lib/story.utils.js
@@ -161,6 +161,7 @@ export const extractDomain = ({
         entities: new Set(defaultDomain.entities || []),
         responses: { ...(defaultDomain.responses || {}), ...responses },
         slots: { ...(defaultDomain.slots || {}), ...getSlotsInRasaFormat(slots) },
+        session_config: defaultDomain.session_config || {},
         forms: {
             ...(defaultDomain.forms || {}),
             ...formGroupIdsToGroupNames(bfForms).reduce(

--- a/botfront/imports/lib/story.utils.tests.js
+++ b/botfront/imports/lib/story.utils.tests.js
@@ -661,6 +661,7 @@ if (Meteor.isServer) {
                 entities: ['name'],
                 responses,
                 slots: {},
+                session_config: {},
                 forms: {},
             });
         });

--- a/botfront/private/fixtures/project01-ee-ext/domain.yml
+++ b/botfront/private/fixtures/project01-ee-ext/domain.yml
@@ -157,6 +157,7 @@ entities:
   - utm_campaign
   - utm_keyword
   - utm_source
+session_config: {}
 forms:
   basic_info_form:
     collect_in_botfront: null

--- a/botfront/private/fixtures/project01/domain.yml
+++ b/botfront/private/fixtures/project01/domain.yml
@@ -159,6 +159,7 @@ entities:
   - utm_keyword
   - utm_source
   - work_email
+session_config: {}
 forms: {}
 intents:
   - another_triggered_one


### PR DESCRIPTION
I added support for the key session_config in the extractDomain function.
Now when session_config is added to the default domain it will be included in the model thats passed to Rasa. 
Appears to work correctly with and without a session_config being included. When session_config is empty Rasa goes for its defaults which appears to be 60 mins in 2x. 

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

