### PR TITLE
fix(axios requestWithJsonBody) add maxBodyLength to axios request

### DIFF
--- a/botfront/imports/lib/utils.js
+++ b/botfront/imports/lib/utils.js
@@ -163,9 +163,9 @@ if (Meteor.isServer) {
                 const axiosJson = axios.create();
                 addLoggingInterceptors(axiosJson, appMethodLogger);
                 // 400mb
-                const maxContentLength = 400000000;
+                const maxContentLength = maxBodyLength = 400000000;
                 const response = await axiosJson({
-                    url, method, data, maxContentLength,
+                    url, method, data, maxContentLength, maxBodyLength
                 });
                 const { status, data: responseData } = response;
                 return { status, data: responseData };

--- a/botfront/imports/lib/utils.js
+++ b/botfront/imports/lib/utils.js
@@ -163,7 +163,8 @@ if (Meteor.isServer) {
                 const axiosJson = axios.create();
                 addLoggingInterceptors(axiosJson, appMethodLogger);
                 // 400mb
-                const maxContentLength = maxBodyLength = 400000000;
+                const maxContentLength = 400000000;
+                const maxBodyLength = 400000000;
                 const response = await axiosJson({
                     url, method, data, maxContentLength, maxBodyLength
                 });


### PR DESCRIPTION
Related to issue #913. 

In the case you intend to add maxBodyLength to the axios.requestWithJsonBody I have made the change and created this pull request. 

This matches the maxContentLength length size of 400mb in order to resolve an issue where using the deployment feature does not work. 

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed
