### PR TITLE
fix(docs): remove botfront entreprise from docs

### DIFF
--- a/docs/guide/administration/roles.md
+++ b/docs/guide/administration/roles.md
@@ -10,11 +10,9 @@ meta:
     content: botfront installation deployment
 ---
 
-Available in: <Premium plan="Botfront Enterprise" />
-
 # RBAC (Role based access control)
 
-The Enterprise Edition allows you to create multiple projects and users.
+Botfront allows you to create multiple projects and users.
 Additionnally you can assign roles to users.
 
 ## Roles and permissions


### PR DESCRIPTION
remove leftover mention of entreprise edition in the docs

- [ ] I wrote tests for the feature
- [ ] I documented the feature if needed

If the feature is a refactor, please explain why your way is better
